### PR TITLE
Run PR workflow on branch refs only

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   build-and-run-tests:
     name: Build & run tests
+    if: github.ref_type == 'branch'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
### Description

Run the PR workflow only when `github.ref` is a branch.

### Type of change

* [ ] New feature
* [ ] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [x] Cleanup / refactoring
* [ ] Other (please explain)
