### PR TITLE
Replace client-cert with x-forwarded-client-cert

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -68,6 +68,7 @@ const (
 	internalConnKey  = "ic"
 	reportEndKey     = "re"
 	backendKey       = "be"
+	serverIDKey      = "si"
 )
 
 var (
@@ -554,7 +555,23 @@ func (p *Proxy) baseTLSConfig() *tls.Config {
 		if hello.ServerName == "" {
 			hello.ServerName = p.defaultServerName()
 		}
-		return getCert(hello)
+		cert, err := getCert(hello)
+		if err != nil {
+			return nil, err
+		}
+		if cert.Leaf != nil {
+			switch {
+			case len(cert.Leaf.URIs) > 0:
+				uris := make([]string, 0, len(cert.Leaf.URIs))
+				for _, u := range cert.Leaf.URIs {
+					uris = append(uris, u.String())
+				}
+				netwConn(hello.Conn).SetAnnotation(serverIDKey, uris)
+			case len(cert.Leaf.DNSNames) > 0:
+				netwConn(hello.Conn).SetAnnotation(serverIDKey, cert.Leaf.DNSNames)
+			}
+		}
+		return cert, nil
 	}
 	// https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids
 	tc.NextProtos = []string{

--- a/proxy/xfcc.go
+++ b/proxy/xfcc.go
@@ -1,0 +1,111 @@
+// MIT License
+//
+// Copyright (c) 2023 TTBT Enterprises LLC
+// Copyright (c) 2023 Robin Thellend <rthellend@rthellend.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package proxy
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/hex"
+	"encoding/pem"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const xFCCHeader = "x-forwarded-client-cert"
+
+func addXFCCHeader(req *http.Request, which []string) {
+	if req.TLS == nil || len(req.TLS.PeerCertificates) == 0 {
+		return
+	}
+	var fields []string
+	conn := netwConn(req.Context().Value(connCtxKey).(*tls.Conn))
+	if serverIDs, ok := conn.Annotation(serverIDKey, nil).([]string); ok {
+		for _, id := range serverIDs {
+			fields = append(fields, "By="+encodeXFCC(id))
+		}
+	}
+	for _, f := range which {
+		switch strings.ToLower(f) {
+		case "cert":
+			fields = append(fields, "Cert="+encodeXFCC(url.QueryEscape(
+				string(pem.EncodeToMemory(&pem.Block{
+					Type:  "CERTIFICATE",
+					Bytes: req.TLS.PeerCertificates[0].Raw,
+				})),
+			)))
+		case "chain":
+			var buf bytes.Buffer
+			for _, cert := range req.TLS.PeerCertificates {
+				pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+			}
+			fields = append(fields, "Chain="+encodeXFCC(url.QueryEscape(buf.String())))
+		case "hash":
+			h := sha256.Sum256(req.TLS.PeerCertificates[0].Raw)
+			fields = append(fields, "Hash="+encodeXFCC(hex.EncodeToString(h[:])))
+		case "subject":
+			fields = append(fields, "Subject="+encodeXFCCSubject(req.TLS.PeerCertificates[0].Subject.String()))
+		case "uri":
+			for _, uri := range req.TLS.PeerCertificates[0].URIs {
+				fields = append(fields, "URI="+encodeXFCC(url.QueryEscape(uri.String())))
+			}
+		case "dns":
+			for _, n := range req.TLS.PeerCertificates[0].DNSNames {
+				fields = append(fields, "DNS="+encodeXFCC(url.QueryEscape(n)))
+			}
+		}
+	}
+	req.Header.Set(xFCCHeader, strings.Join(fields, ";"))
+}
+
+func encodeXFCCSubject(input string) string {
+	var parts []string
+	var esc bool
+	s := &strings.Builder{}
+	for _, r := range input {
+		if r == ',' && !esc {
+			parts = append(parts, s.String())
+			s.Reset()
+			esc = false
+			continue
+		}
+
+		esc = !esc && r == '\\'
+		s.WriteRune(r)
+	}
+	if s.Len() > 0 {
+		parts = append(parts, s.String())
+	}
+	return encodeXFCC("/" + strings.Join(parts, "/"))
+}
+
+func encodeXFCC(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	if strings.ContainsAny(s, ",;=") {
+		s = `"` + s + `"`
+	}
+	return s
+}

--- a/proxy/xfcc_test.go
+++ b/proxy/xfcc_test.go
@@ -1,0 +1,65 @@
+// MIT License
+//
+// Copyright (c) 2023 TTBT Enterprises LLC
+// Copyright (c) 2023 Robin Thellend <rthellend@rthellend.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package proxy
+
+import (
+	"testing"
+)
+
+func TestEncodeXFCC(t *testing.T) {
+	for _, tc := range []struct {
+		input  string
+		output string
+	}{
+		{input: `foo`, output: `foo`},
+		{input: `foo&?!`, output: `foo&?!`},
+		{input: `foo,bar`, output: `"foo,bar"`},
+		{input: `foo;bar`, output: `"foo;bar"`},
+		{input: `foo=bar`, output: `"foo=bar"`},
+		{input: `"foo`, output: `\"foo`},
+		{input: ``, output: ``},
+	} {
+		if got, want := encodeXFCC(tc.input), tc.output; got != want {
+			t.Errorf("encodeXFCC(%q) = %q, want %q", tc.input, got, want)
+		}
+	}
+}
+
+func TestEncodeXFCCSubject(t *testing.T) {
+	for _, tc := range []struct {
+		input  string
+		output string
+	}{
+		{input: `CN=foo`, output: `"/CN=foo"`},
+		{input: `O=Org,CN=foo`, output: `"/O=Org/CN=foo"`},
+		{input: `C=US,O=Org,CN=foo`, output: `"/C=US/O=Org/CN=foo"`},
+		{input: `O=Org\,org=\,org=,CN=foo`, output: `"/O=Org\\,org=\\,org=/CN=foo"`},
+		{input: `O=Org,org=,org=,CN=foo`, output: `"/O=Org/org=/org=/CN=foo"`},
+		{input: ``, output: `/`},
+	} {
+		if got, want := encodeXFCCSubject(tc.input), tc.output; got != want {
+			t.Errorf("encodeXFCCSubject(%q) = %q, want %q", tc.input, got, want)
+		}
+	}
+}


### PR DESCRIPTION
### Description

Replace client-cert with x-forwarded-client-cert. The value of the `AddClientCertHeader` field is now a list of xfcc fields to include in the header: cert, chain, hash, subject, uri, and/or dns.

### Type of change

* [x] New feature
* [x] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)


### How is this change tested ?

* [x] Unit tests
* [ ] Manual tests (explain)
* [ ] Tests are not needed
