### PR TITLE
Add a local OIDC provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 config.yaml
 version.sh
+bin

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Overview of features:
 * [x] Terminate _TCP_ connections, and forward the TLS connection to any TLS server (passthrough). The proxy doesn't see the plaintext.
 * [x] Terminate HTTPS connections, and forward the requests to HTTP or HTTPS servers (http/1 only, not recommended with c2fmzq-server).
 * [x] TLS client authentication & authorization (when the proxy terminates the TLS connections).
-* [x] User authentication with OpenID Connect and SAML (for HTTP and HTTPS connections). Optionally issue JSON Web Tokens (JWT) to authenticated users to use with the backend services.
+* [x] User authentication with OpenID Connect and SAML (for HTTP and HTTPS connections). Optionally issue JSON Web Tokens (JWT) to authenticated users to use with the backend services and/or run a local OpenID Connect server for backend services.
 * [x] Access control by IP address.
 * [x] Routing based on Server Name Indication (SNI), with optional default route when SNI isn't used.
 * [x] Simple round-robin load balancing between servers.

--- a/proxy/backend-sso.go
+++ b/proxy/backend-sso.go
@@ -85,7 +85,9 @@ func (be *Backend) userAuthentication(next http.Handler) http.Handler {
 			if claims != nil {
 				sub, err := claims.GetSubject()
 				if err == nil && sub != "" {
-					req.Header.Set(xTLSProxyUserIDHeader, sub)
+					if be.SSO.SetUserIDHeader {
+						req.Header.Set(xTLSProxyUserIDHeader, sub)
+					}
 					req = req.WithContext(context.WithValue(req.Context(), authCtxKey, claims))
 				}
 			}

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -335,6 +335,9 @@ type BackendSSO struct {
 	// Paths lists the path prefixes for which this policy will be enforced.
 	// If Paths is empty, the policy applies to all paths.
 	Paths []string `yaml:"paths,omitempty"`
+	// SetUserIDHeader indicates that the x-tlsproxy-user-id header should
+	// be set with the email address of the user.
+	SetUserIDHeader bool `yaml:"setUserIdHeader"`
 	// GenerateIDTokens indicates that the proxy should generate ID tokens
 	// for authenticated users.
 	GenerateIDTokens bool `yaml:"generateIdTokens,omitempty"`

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -361,7 +361,9 @@ type LocalOIDCServer struct {
 	PathPrefix string `yaml:"pathPrefix,omitempty"`
 	// Clients is the list of all authorized clients and their
 	// configurations.
-	Clients      []*LocalOIDCClient      `yaml:"clients,omitempty"`
+	Clients []*LocalOIDCClient `yaml:"clients,omitempty"`
+	// RewriteRules are used to rewrite existing claims or create new claims
+	// from existing ones.
 	RewriteRules []*LocalOIDCRewriteRule `yaml:"rewriteRules,omitempty"`
 }
 
@@ -381,6 +383,15 @@ type LocalOIDCClient struct {
 	RedirectURI []string `yaml:"redirectUri"`
 }
 
+// LocalOIDCRewriteRule define how to rewrite existing claims or create new
+// claims from existing ones.
+// The following example uses the "email" claim to create a "preferred_username"
+// claim by removing the domain name.
+//
+//	InputClaim: "email"
+//	OutputClaim: "preferred_username"
+//	Regex: "^([^@]+)@example.com$"
+//	Value: "$1"
 type LocalOIDCRewriteRule struct {
 	InputClaim  string `yaml:"inputClaim"`
 	OutputClaim string `yaml:"outputClaim"`

--- a/proxy/http.go
+++ b/proxy/http.go
@@ -100,7 +100,9 @@ func (l *proxyListener) Addr() net.Addr {
 	return l.addr
 }
 
-func logRequest(req *http.Request) {
-	desc := formatReqDesc(req)
-	log.Printf("REQ %s ➔ %s %s", desc, req.Method, req.URL)
+func logHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		log.Printf("REQ %s ➔ %s %s", formatReqDesc(req), req.Method, req.URL)
+		next.ServeHTTP(w, req)
+	})
 }

--- a/proxy/internal/cookiemanager/cookiemanager_test.go
+++ b/proxy/internal/cookiemanager/cookiemanager_test.go
@@ -46,7 +46,7 @@ func TestCookies(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	cm := New(tm, "example.com", "https://idp.example.com")
+	cm := New(tm, "idp", "example.com", "https://idp.example.com")
 
 	recorder := httptest.NewRecorder()
 

--- a/proxy/internal/oidc/server.go
+++ b/proxy/internal/oidc/server.go
@@ -1,0 +1,480 @@
+// MIT License
+//
+// Copyright (c) 2023 TTBT Enterprises LLC
+// Copyright (c) 2023 Robin Thellend <rthellend@rthellend.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package oidc
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"maps"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	jwt "github.com/golang-jwt/jwt/v5"
+
+	"github.com/c2FmZQ/tlsproxy/proxy/internal/tokenmanager"
+)
+
+const (
+	wellKnownOpenIDConfigurationPath = "/.well-known/openid-configuration"
+	authorizationPath                = "/authorization"
+	tokenPath                        = "/token"
+	userInfoPath                     = "/userinfo"
+	jwksPath                         = "/jwks"
+)
+
+type openIDConfiguration struct {
+	Issuer                           string   `json:"issuer"`
+	AuthorizationEndpoint            string   `json:"authorization_endpoint"`
+	TokenEndpoint                    string   `json:"token_endpoint"`
+	UserInfoEndpoint                 string   `json:"userinfo_endpoint"`
+	JWKSURI                          string   `json:"jwks_uri"`
+	ResponseTypesSupported           []string `json:"response_types_supported"`
+	SubjectTypesSupported            []string `json:"subject_types_supported"`
+	IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
+	ScopesSupported                  []string `json:"scopes_supported"`
+	ClaimsSupported                  []string `json:"claims_supported"`
+}
+
+type codeData struct {
+	created     time.Time
+	clientID    string
+	token       string
+	scope       string
+	accessToken string
+}
+
+type accessData struct {
+	created  time.Time
+	clientID string
+	claims   jwt.MapClaims
+}
+
+// ServerOptions contains the parameters needed to configure a ProviderServer.
+type ServerOptions struct {
+	TokenManager  *tokenmanager.TokenManager
+	Issuer        string
+	PathPrefix    string
+	ClaimsFromCtx func(context.Context) jwt.Claims
+	Clients       []Client
+	RewriteRules  []RewriteRule
+
+	EventRecorder EventRecorder
+}
+
+// RewriteRule is used to apply a regular expression on an existing JWT claim
+// to create or overwrite another claim, or possibly the same claim.
+type RewriteRule struct {
+	InputClaim  string
+	OutputClaim string
+	Regex       string
+	Value       string
+}
+
+// NewServer returns a new ProviderServer.
+func NewServer(opts ServerOptions) *ProviderServer {
+	return &ProviderServer{
+		opts:         opts,
+		codes:        make(map[string]*codeData),
+		accessTokens: make(map[string]*accessData),
+	}
+}
+
+// ProviderServer is a OpenID Connect server implementation.
+// https://openid.net/specs/openid-connect-discovery-1_0.html
+// https://openid.net/specs/openid-connect-basic-1_0.html
+type ProviderServer struct {
+	opts ServerOptions
+
+	mu           sync.Mutex
+	codes        map[string]*codeData
+	accessTokens map[string]*accessData
+}
+
+type Client struct {
+	ID          string
+	Secret      string
+	RedirectURI []string
+}
+
+func (s *ProviderServer) vacuum() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now().UTC()
+	for k, v := range s.codes {
+		if v.created.Add(2 * time.Minute).Before(now) {
+			delete(s.codes, k)
+		}
+	}
+	for k, v := range s.accessTokens {
+		if v.created.Add(2 * time.Minute).Before(now) {
+			delete(s.accessTokens, k)
+		}
+	}
+}
+
+func (s *ProviderServer) ServeConfig(w http.ResponseWriter, req *http.Request) {
+	host := req.Host
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	cfg := openIDConfiguration{
+		Issuer:                s.opts.Issuer,
+		AuthorizationEndpoint: fmt.Sprintf("https://%s%s%s", host, s.opts.PathPrefix, authorizationPath),
+		TokenEndpoint:         fmt.Sprintf("https://%s%s%s", host, s.opts.PathPrefix, tokenPath),
+		UserInfoEndpoint:      fmt.Sprintf("https://%s%s%s", host, s.opts.PathPrefix, userInfoPath),
+		JWKSURI:               fmt.Sprintf("https://%s%s%s", host, s.opts.PathPrefix, jwksPath),
+		ResponseTypesSupported: []string{
+			"code",
+		},
+		SubjectTypesSupported: []string{
+			"public",
+		},
+		IDTokenSigningAlgValuesSupported: []string{
+			"RS256",
+			"ES256",
+		},
+		ScopesSupported: []string{
+			"openid",
+			"email",
+			"profile",
+		},
+		ClaimsSupported: []string{
+			"aud",
+			"email",
+			"exp",
+			"family_name",
+			"middle_name",
+			"given_name",
+			"iat",
+			"iss",
+			"locale",
+			"name",
+			"picture",
+			"sub",
+		},
+	}
+
+	s.opts.EventRecorder.Record("allow openid config request")
+	content, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	sum := sha256.Sum256(content)
+	etag := `"` + hex.EncodeToString(sum[:]) + `"`
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	w.Header().Set("Etag", etag)
+
+	if e := req.Header.Get("If-None-Match"); e == etag {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	w.Write(content)
+}
+
+func (s *ProviderServer) ServeAuthorization(w http.ResponseWriter, req *http.Request) {
+	s.vacuum()
+	userClaims := s.opts.ClaimsFromCtx(req.Context())
+	if userClaims == nil {
+		http.Error(w, "not logged in", http.StatusUnauthorized)
+		return
+	}
+	req.ParseForm()
+	if rt := req.Form.Get("response_type"); rt != "code" {
+		log.Printf("ERR ServeAuthorization: invalid response_type %q", rt)
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	clientID := req.Form.Get("client_id")
+	redirectURI := req.Form.Get("redirect_uri")
+	var found bool
+	for _, client := range s.opts.Clients {
+		if client.ID == clientID && slices.Contains(client.RedirectURI, redirectURI) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		log.Printf("ERR ServeAuthorization: invalid client_id %q or redirect_uri %q", clientID, redirectURI)
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+
+	ru, err := url.Parse(redirectURI)
+	if err != nil {
+		log.Printf("ERR ServeAuthorization: invalid redirect_uri %q", redirectURI)
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+
+	b := make([]byte, 12)
+	if _, err := io.ReadFull(rand.Reader, b); err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	code := base64.StdEncoding.EncodeToString(b)
+	b = make([]byte, 12)
+	if _, err := io.ReadFull(rand.Reader, b); err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	accessToken := base64.StdEncoding.EncodeToString(b)
+
+	sub, _ := userClaims.GetSubject()
+
+	now := time.Now().UTC()
+	claims := jwt.MapClaims{
+		"iat":   now.Unix(),
+		"exp":   now.Add(5 * time.Minute).Unix(),
+		"iss":   s.opts.Issuer,
+		"aud":   clientID,
+		"sub":   sub,
+		"scope": "openid",
+	}
+	if nonce := req.Form.Get("nonce"); nonce != "" {
+		claims["nonce"] = nonce
+	}
+
+	sc := "openid"
+	scopes := strings.Split(req.Form.Get("scope"), " ")
+	if slices.Contains(scopes, "email") {
+		claims["email"] = claims["sub"]
+		claims["email_verified"] = true
+		sc += " email"
+	}
+	uc, ok := userClaims.(jwt.MapClaims)
+	if !ok {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if slices.Contains(scopes, "profile") {
+		for _, v := range []string{"name", "family_name", "given_name", "middle_name", "nickname", "preferred_username", "profile", "picture", "website", "gender", "birthdate", "zoneinfo", "locale"} {
+			if vv := uc[v]; vv != nil {
+				claims[v] = vv
+			}
+		}
+		sc += " profile"
+	}
+	claims["scope"] = sc
+
+	applyRewriteRules(s.opts.RewriteRules, uc, claims)
+
+	token, err := s.opts.TokenManager.CreateToken(claims, "RS256")
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	s.mu.Lock()
+	s.codes[code] = &codeData{
+		created:     now,
+		clientID:    clientID,
+		token:       token,
+		scope:       sc,
+		accessToken: accessToken,
+	}
+	s.accessTokens[accessToken] = &accessData{
+		created:  now,
+		clientID: clientID,
+		claims:   claims,
+	}
+	s.mu.Unlock()
+
+	qs := ru.Query()
+	qs.Set("state", req.Form.Get("state"))
+	qs.Set("code", code)
+	qs.Set("scope", sc)
+	ru.RawQuery = qs.Encode()
+
+	s.opts.EventRecorder.Record("allow openid auth request for " + clientID)
+	http.Redirect(w, req, ru.String(), http.StatusFound)
+}
+
+func (s *ProviderServer) ServeToken(w http.ResponseWriter, req *http.Request) {
+	s.vacuum()
+	if req.Method != http.MethodPost {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	req.ParseForm()
+	if gt := req.Form.Get("grant_type"); gt != "authorization_code" {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	code := req.Form.Get("code")
+	clientID := req.Form.Get("client_id")
+	clientSecret := req.Form.Get("client_secret")
+	redirectURI := req.Form.Get("redirect_uri")
+
+	var found bool
+	for _, client := range s.opts.Clients {
+		if client.ID == clientID && client.Secret == clientSecret && slices.Contains(client.RedirectURI, redirectURI) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+
+	s.mu.Lock()
+	data, ok := s.codes[code]
+	delete(s.codes, code)
+	s.mu.Unlock()
+
+	if !ok || data.clientID != clientID {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+
+	resp := struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+		IDToken     string `json:"id_token"`
+		Scope       string `json:"scope"`
+		TokenType   string `json:"token_type"`
+	}{
+		AccessToken: data.accessToken,
+		ExpiresIn:   90,
+		IDToken:     data.token,
+		Scope:       data.scope,
+		TokenType:   "Bearer",
+	}
+
+	s.opts.EventRecorder.Record("allow openid token request for " + clientID)
+	content, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-cache, no-store")
+	w.WriteHeader(http.StatusOK)
+	w.Write(content)
+}
+
+func (s *ProviderServer) ServeUserInfo(w http.ResponseWriter, req *http.Request) {
+	s.vacuum()
+	if req.Method != http.MethodGet && req.Method != http.MethodPost {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	accessToken := req.Header.Get("Authorization")
+	if len(accessToken) < 7 || strings.ToLower(accessToken[:7]) != "bearer " {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+	accessToken = accessToken[7:]
+
+	s.mu.Lock()
+	data, ok := s.accessTokens[accessToken]
+	delete(s.accessTokens, accessToken)
+	s.mu.Unlock()
+	if !ok {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+
+	filter := map[string]bool{
+		"iss":   true,
+		"aud":   true,
+		"iat":   true,
+		"exp":   true,
+		"nbf":   true,
+		"scope": true,
+		"sid":   true,
+		"nonce": true,
+	}
+	out := make(map[string]interface{})
+	for k, v := range data.claims {
+		if !filter[k] {
+			out[k] = v
+		}
+	}
+
+	s.opts.EventRecorder.Record("allow openid userinfo request for " + data.clientID)
+	content, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-cache, no-store")
+	w.WriteHeader(http.StatusOK)
+	w.Write(content)
+}
+
+func applyRewriteRules(rules []RewriteRule, in, out jwt.MapClaims) {
+	buf := maps.Clone(in)
+	getClaim := func(n string) string {
+		ii, exists := buf[n]
+		if !exists {
+			return ""
+		}
+		switch v := ii.(type) {
+		case string:
+			return v
+		default:
+			return fmt.Sprintf("%v", ii)
+		}
+	}
+	for _, rr := range rules {
+		var input string
+		if strings.Contains(rr.InputClaim, "$") {
+			input = os.Expand(rr.InputClaim, getClaim)
+		} else {
+			input = getClaim(rr.InputClaim)
+		}
+		re, err := regexp.Compile(rr.Regex)
+		if err != nil {
+			log.Printf("ERR REGEX %q: %v", rr.Regex, err)
+			continue
+		}
+		if !re.MatchString(input) {
+			continue
+		}
+		v := re.ReplaceAllString(input, rr.Value)
+		buf[rr.OutputClaim] = v
+		out[rr.OutputClaim] = v
+		log.Printf("DBG REGEX %s: %q -> %q", rr.OutputClaim, input, v)
+	}
+}

--- a/proxy/internal/oidc/server.go
+++ b/proxy/internal/oidc/server.go
@@ -446,16 +446,16 @@ func (s *ProviderServer) ServeUserInfo(w http.ResponseWriter, req *http.Request)
 func applyRewriteRules(rules []RewriteRule, in, out jwt.MapClaims) {
 	buf := maps.Clone(in)
 	getClaim := func(n string) string {
-		ii, exists := buf[n]
-		if !exists {
-			return ""
+		if v, exists := buf[n]; exists {
+			return fmt.Sprint(v)
 		}
-		switch v := ii.(type) {
-		case string:
-			return v
-		default:
-			return fmt.Sprintf("%v", ii)
+		if v, exists := buf[strings.TrimSuffix(n, ":lower")]; exists {
+			return strings.ToLower(fmt.Sprint(v))
 		}
+		if v, exists := buf[strings.TrimSuffix(n, ":upper")]; exists {
+			return strings.ToUpper(fmt.Sprint(v))
+		}
+		return ""
 	}
 	for _, rr := range rules {
 		var input string

--- a/proxy/internal/oidc/server_test.go
+++ b/proxy/internal/oidc/server_test.go
@@ -31,8 +31,10 @@ import (
 
 func TestRewriteRules(t *testing.T) {
 	in := jwt.MapClaims{
-		"email": "alice@EXAMPLE.COM",
-		"name":  "Jane Doe",
+		"email":       "jane@EXAMPLE.COM",
+		"name":        "Jane Doe",
+		"given_name":  "Jane",
+		"family_name": "Doe",
 	}
 	out := jwt.MapClaims{}
 
@@ -55,17 +57,32 @@ func TestRewriteRules(t *testing.T) {
 			Regex:       "^(.*)$",
 			Value:       "$1",
 		},
+		{
+			InputClaim:  "${given_name:lower}",
+			OutputClaim: "username2",
+			Regex:       "^(.).*$",
+			Value:       "$1",
+		},
+		{
+			InputClaim:  "${username2}${family_name:lower}",
+			OutputClaim: "username2",
+			Regex:       "^(.*)$",
+			Value:       "$1",
+		},
 	}
 
 	applyRewriteRules(rr, in, out)
 
-	if want, got := "alice", out["preferred_username"]; want != got {
+	if want, got := "jane", out["preferred_username"]; want != got {
 		t.Errorf("preferred_username = %q, want %q", got, want)
 	}
 	if want, got := "JaneDoe", out["name_nospace"]; want != got {
 		t.Errorf("name_nospace = %q, want %q", got, want)
 	}
-	if want, got := "Jane Doe <alice@EXAMPLE.COM>", out["name_and_email"]; want != got {
+	if want, got := "Jane Doe <jane@EXAMPLE.COM>", out["name_and_email"]; want != got {
 		t.Errorf("name_and_email = %q, want %q", got, want)
+	}
+	if want, got := "jdoe", out["username2"]; want != got {
+		t.Errorf("username2 = %q, want %q", got, want)
 	}
 }

--- a/proxy/internal/saml/saml.go
+++ b/proxy/internal/saml/saml.go
@@ -142,11 +142,6 @@ func (p *Provider) RequestLogin(w http.ResponseWriter, req *http.Request, origUR
 func (p *Provider) HandleCallback(w http.ResponseWriter, req *http.Request) {
 	p.er.Record("saml auth callback")
 	req.ParseForm()
-	if req.Form.Get("logout") != "" {
-		p.cm.ClearCookies(w)
-		w.Write([]byte("logout successful"))
-		return
-	}
 
 	if req.Method != http.MethodPost {
 		http.Error(w, "invalid method", http.StatusForbidden)
@@ -234,7 +229,9 @@ func (p *Provider) HandleCallback(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	extraClaims := make(map[string]string)
+	extraClaims := map[string]string{
+		"source": findElementText(v, "./Issuer"),
+	}
 	for _, a := range v.FindElements("./AttributeStatement/Attribute") {
 		attr := a.SelectAttr("Name")
 		if attr == nil {

--- a/proxy/internal/tokenmanager/tokenmanager_test.go
+++ b/proxy/internal/tokenmanager/tokenmanager_test.go
@@ -49,7 +49,7 @@ func TestTokenManager(t *testing.T) {
 		"sub": "test@example.com",
 		"iss": "https://login.example.com",
 		"aud": "https://login.example.com",
-	})
+	}, "ES256")
 	if err != nil {
 		t.Fatalf("tm.CreateToken: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestTokenManager(t *testing.T) {
 		"sub": "test@example.com",
 		"iss": "https://login.example.com",
 		"aud": "https://login.example.com",
-	})
+	}, "RS256")
 	if err != nil {
 		t.Fatalf("tm.CreateToken: %v", err)
 	}

--- a/proxy/logout-template.html
+++ b/proxy/logout-template.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Logout</title>
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=10, minimum-scale=0.1" />
+<link rel="icon" href="/.sso/favicon.ico" />
+<style>
+html {
+  margin: 0;
+  height: 100%;
+  background-color: black;
+} 
+body {
+  margin: 0;
+  height: 100%;
+  font-family: monospace;
+}
+#message {
+  color: white;
+  text-align: center;
+  position: fixed;
+  left: 50vw;
+  top: 40vh;
+  transform: translate(-50%, -50%);
+  padding: 10px;
+  max-width: 90vw;
+}
+</style>
+</head>
+<body>
+<div id="message">
+<div>Logged out</div>
+</div>
+</div>
+</body>
+</html>

--- a/proxy/metrics.go
+++ b/proxy/metrics.go
@@ -266,6 +266,14 @@ func (p *Proxy) configHandler(w http.ResponseWriter, req *http.Request) {
 	for _, p := range cfg.OIDCProviders {
 		p.ClientSecret = "**REDACTED**"
 	}
+	for _, be := range cfg.Backends {
+		if be.SSO == nil || be.SSO.LocalOIDCServer == nil {
+			continue
+		}
+		for _, client := range be.SSO.LocalOIDCServer.Clients {
+			client.Secret = "**REDACTED**"
+		}
+	}
 	w.Header().Set("content-type", "text/plain; charset=utf-8")
 	enc := yaml.NewEncoder(w)
 	enc.SetIndent(2)

--- a/proxy/permission-denied-template.html
+++ b/proxy/permission-denied-template.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Permission denied</title>
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=10, minimum-scale=0.1" />
+<style>
+html {
+  margin: 0;
+  height: 100%;
+  background-color: black;
+} 
+body {
+  margin: 0;
+  height: 100%;
+  font-family: monospace;
+}
+a {
+  color: white;
+}
+#buttons {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+}
+a.button {
+  text-decoration: none;
+  border: solid 1px black;
+  background-color: lightgray;
+  color: black;
+  margin: 1em;
+  padding: 0.5em;
+}
+a.button:hover {
+  background-color: darkgray;
+}
+#message {
+  color: white;
+  text-align: center;
+  position: fixed;
+  left: 50vw;
+  top: 40vh;
+  transform: translate(-50%, -50%);
+  padding: 10px;
+  max-width: 90vw;
+}
+#target {
+  margin: 2em;
+}
+.big {
+  font-size: 800%;
+}
+</style>
+</head>
+<body>
+<div id="buttons">
+<a class="button" href="/.sso/logout?u={{.Token}}">Switch Account</a>
+<a class="button" href="/.sso/logout">Logout</a>
+</div>
+<div id="message">
+<div class="big">🛂</div>
+<div>{{.Subject}} is not allowed to access</div>
+<div id="target"><a href="{{.URL}}">{{.DisplayURL}}</a></div>
+</div>
+</div>
+</body>
+</html>

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -415,7 +415,7 @@ func (p *Proxy) Reconfigure(cfg *Config) error {
 		case ModeConsole:
 			be := be
 			be.localHandlers["/"] = localHandler{handler: http.HandlerFunc(p.metricsHandler)}
-			be.localHandlers["/favicon.ico"] = localHandler{handler: http.HandlerFunc(p.faviconHandler), ssoBypass: true}
+			be.localHandlers["/favicon.ico"] = localHandler{handler: http.HandlerFunc(p.faviconHandler)}
 			be.localHandlers["/config"] = localHandler{handler: http.HandlerFunc(p.configHandler)}
 			addPProfHandlers(be.localHandlers)
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -238,7 +238,7 @@ func (p *Proxy) Reconfigure(cfg *Config) error {
 			return err
 		}
 		issuer := "https://" + host + "/"
-		cm := cookiemanager.New(p.tokenManager, pp.Domain, issuer)
+		cm := cookiemanager.New(p.tokenManager, pp.Name, pp.Domain, issuer)
 		oidcCfg := oidc.Config{
 			DiscoveryURL:  pp.DiscoveryURL,
 			AuthEndpoint:  pp.AuthEndpoint,
@@ -266,7 +266,7 @@ func (p *Proxy) Reconfigure(cfg *Config) error {
 			return err
 		}
 		issuer := "https://" + host + "/"
-		cm := cookiemanager.New(p.tokenManager, pp.Domain, issuer)
+		cm := cookiemanager.New(p.tokenManager, pp.Name, pp.Domain, issuer)
 		samlCfg := saml.Config{
 			SSOURL:   pp.SSOURL,
 			EntityID: pp.EntityID,
@@ -290,18 +290,77 @@ func (p *Proxy) Reconfigure(cfg *Config) error {
 	for _, be := range cfg.Backends {
 		be.localHandlers = make(map[string]localHandler)
 		be.recordEvent = p.recordEvent
+		be.tm = p.tokenManager
 
 		for _, sn := range be.ServerNames {
 			backends[sn] = be
 		}
 		if be.SSO != nil {
-			p, ok := identityProviders[be.SSO.Provider]
+			idp, ok := identityProviders[be.SSO.Provider]
 			if !ok {
 				return fmt.Errorf("unknown identity provider: %q", be.SSO.Provider)
 			}
-			be.SSO.p = p.identityProvider
-			be.SSO.domain = p.domain
-			be.SSO.cm = p.cm
+			be.SSO.p = idp.identityProvider
+			be.SSO.domain = idp.domain
+			be.SSO.cm = idp.cm
+			be.localHandlers["/.sso/"] = localHandler{
+				handler:   logHandler(http.HandlerFunc(be.serveSSOStatus)),
+				ssoBypass: true,
+			}
+			be.localHandlers["/.sso/logout"] = localHandler{
+				handler:   logHandler(http.HandlerFunc(be.serveLogout)),
+				ssoBypass: true,
+			}
+			be.localHandlers["/.sso/favicon.ico"] = localHandler{
+				handler:   http.HandlerFunc(p.faviconHandler),
+				ssoBypass: true,
+			}
+
+			if ls := be.SSO.LocalOIDCServer; ls != nil && len(be.ServerNames) > 0 {
+				opts := oidc.ServerOptions{
+					TokenManager:  p.tokenManager,
+					Issuer:        "https://" + be.ServerNames[0] + ls.PathPrefix,
+					PathPrefix:    ls.PathPrefix,
+					ClaimsFromCtx: claimsFromCtx,
+					Clients:       make([]oidc.Client, 0, len(ls.Clients)),
+					EventRecorder: er,
+				}
+				for _, client := range ls.Clients {
+					opts.Clients = append(opts.Clients, oidc.Client{
+						ID:          client.ID,
+						Secret:      client.Secret,
+						RedirectURI: client.RedirectURI,
+					})
+				}
+				for _, rr := range ls.RewriteRules {
+					opts.RewriteRules = append(opts.RewriteRules, oidc.RewriteRule{
+						InputClaim:  rr.InputClaim,
+						OutputClaim: rr.OutputClaim,
+						Regex:       rr.Regex,
+						Value:       rr.Value,
+					})
+				}
+				oidcServer := oidc.NewServer(opts)
+				be.localHandlers[ls.PathPrefix+"/.well-known/openid-configuration"] = localHandler{
+					handler:   logHandler(http.HandlerFunc(oidcServer.ServeConfig)),
+					ssoBypass: true,
+				}
+				be.localHandlers[ls.PathPrefix+"/authorization"] = localHandler{
+					handler: logHandler(http.HandlerFunc(oidcServer.ServeAuthorization)),
+				}
+				be.localHandlers[ls.PathPrefix+"/token"] = localHandler{
+					handler:   logHandler(http.HandlerFunc(oidcServer.ServeToken)),
+					ssoBypass: true,
+				}
+				be.localHandlers[ls.PathPrefix+"/userinfo"] = localHandler{
+					handler:   logHandler(http.HandlerFunc(oidcServer.ServeUserInfo)),
+					ssoBypass: true,
+				}
+				be.localHandlers[ls.PathPrefix+"/jwks"] = localHandler{
+					handler:   logHandler(http.HandlerFunc(p.tokenManager.ServeJWKS)),
+					ssoBypass: true,
+				}
+			}
 		}
 		tc := p.baseTLSConfig()
 		if be.ClientAuth != nil {
@@ -348,19 +407,16 @@ func (p *Proxy) Reconfigure(cfg *Config) error {
 		}
 		if be.ExportJWKS != "" {
 			be.localHandlers[be.ExportJWKS] = localHandler{
-				handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-					logRequest(req)
-					p.tokenManager.ServeJWKS(w, req)
-				}),
+				handler:   logHandler(http.HandlerFunc(p.tokenManager.ServeJWKS)),
 				ssoBypass: true,
 			}
 		}
 		switch be.Mode {
 		case ModeConsole:
 			be := be
-			be.localHandlers["/"] = localHandler{handler: p.metricsHandler}
-			be.localHandlers["/favicon.ico"] = localHandler{handler: p.faviconHandler}
-			be.localHandlers["/config"] = localHandler{handler: p.configHandler}
+			be.localHandlers["/"] = localHandler{handler: http.HandlerFunc(p.metricsHandler)}
+			be.localHandlers["/favicon.ico"] = localHandler{handler: http.HandlerFunc(p.faviconHandler), ssoBypass: true}
+			be.localHandlers["/config"] = localHandler{handler: http.HandlerFunc(p.configHandler)}
 			addPProfHandlers(be.localHandlers)
 
 			be.httpConnChan = make(chan net.Conn)
@@ -857,10 +913,10 @@ func (p *Proxy) backend(serverName string) (*Backend, error) {
 }
 
 func formatReqDesc(req *http.Request) string {
-	userID := req.Header.Get(xTLSProxyUserIDHeader)
 	var ids []string
-	if userID != "" {
-		ids = append(ids, userID)
+	if claims := claimsFromCtx(req.Context()); claims != nil {
+		sub, _ := claims.GetSubject()
+		ids = append(ids, sub)
 	}
 	tlsConn := req.Context().Value(connCtxKey).(*tls.Conn)
 	return formatConnDesc(tlsConn.NetConn().(*netw.Conn), ids...)

--- a/proxy/sso-status-template.html
+++ b/proxy/sso-status-template.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Status</title>
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=10, minimum-scale=0.1" />
+<link rel="icon" href="/.sso/favicon.ico" />
+<style>
+html {
+  margin: 0;
+  height: 100%;
+  background-color: black;
+} 
+body {
+  margin: 0;
+  height: 100%;
+  font-family: monospace;
+}
+#buttons {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+}
+a.button {
+  text-decoration: none;
+  border: solid 1px black;
+  background-color: lightgray;
+  color: black;
+  margin: 1em;
+  padding: 0.5em;
+}
+a.button:hover {
+  background-color: darkgray;
+}
+#message {
+  color: white;
+  text-align: left;
+  position: fixed;
+  left: 50vw;
+  top: 50vh;
+  transform: translate(-50%, -50%);
+  border: solid 1px gray;
+  padding: 1em;
+  width: clamp(20em, 40em, 90vw);
+  max-height: 80vh;
+  overflow: scroll;
+  background-color: black;
+}
+#claims {
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: 0;
+  padding: 0;
+  border: solid 1px #606060;
+}
+#claims > div {
+  border: solid 1px #404040;
+  margin: 0;
+  padding: 0.25em;
+  overflow: scroll;
+  white-space: nowrap;
+}
+</style>
+</head>
+<body>
+<div id="buttons">
+<a class="button" href="/.sso/logout?u={{.Token}}">Switch Account</a>
+<a class="button" href="/.sso/logout">Logout</a>
+</div>
+<div id="message">
+{{ if len .Claims | ne 0 }}
+User Identity:
+<div id="claims">
+{{ range .Claims }}
+<div>{{.Key}}</div>
+<div>{{.Value}}{{ if eq .Key "picture" }}<br /><img style="max-width: 40vw; max-height: 40vh;" src="{{.Value}}" />{{ end }}</div>
+{{ end }}
+{{ else }}
+User Is Not Logged In
+{{ end }}
+</div>
+</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
### Description

Implement a local OIDC provider _server_ to enable SSO on backend services that support OIDC. This new built-in server uses the existing user identity provided by SAML and/or OIDC.

Claims can be rewritten to match the needs of the local clients, e.g. the `email` claim can used to derive a `preferred_username` claim by removing the `@domain` part.

### Type of change

* [x] New feature
* [ ] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)


### How is this change tested ?

* [x] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
