### PR TITLE
Add authentication with passkeys

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '>=1.21.1'
+        go-version: '>=1.21.2'
     - name: Build
       run: go build ./...
     - name: Run go vet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '>=1.21.1'
+        go-version: '>=1.21.2'
     - name: Build
       run: go build ./...
     - name: Run go vet
@@ -39,7 +39,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '>=1.21.1'
+        go-version: '>=1.21.2'
     - name: Build release binaries
       run: ./build-release-binaries.sh
     - name: Create release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.1-alpine3.18 AS build
+FROM golang:1.21.2-alpine3.18 AS build
 MAINTAINER info@c2fmzq.org
 RUN apk update && apk upgrade
 RUN apk add ca-certificates

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Overview of features:
 * [x] Terminate _TCP_ connections, and forward the TLS connection to any TLS server (passthrough). The proxy doesn't see the plaintext.
 * [x] Terminate HTTPS connections, and forward the requests to HTTP or HTTPS servers (http/1 only, not recommended with c2fmzq-server).
 * [x] TLS client authentication & authorization (when the proxy terminates the TLS connections).
-* [x] User authentication with OpenID Connect and SAML (for HTTP and HTTPS connections). Optionally issue JSON Web Tokens (JWT) to authenticated users to use with the backend services and/or run a local OpenID Connect server for backend services.
+* [x] User authentication with OpenID Connect, SAML, and/or passkeys (for HTTP and HTTPS connections). Optionally issue JSON Web Tokens (JWT) to authenticated users to use with the backend services and/or run a local OpenID Connect server for backend services.
 * [x] Access control by IP address.
 * [x] Routing based on Server Name Indication (SNI), with optional default route when SNI isn't used.
 * [x] Simple round-robin load balancing between servers.

--- a/examples/backend/go.mod
+++ b/examples/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/c2FmZQ/tlsproxy/examples/backend
 
-go 1.21.1
+go 1.21.2
 
 require (
 	github.com/blend/go-sdk v1.20220411.3

--- a/examples/sso/README.md
+++ b/examples/sso/README.md
@@ -1,6 +1,6 @@
-# User authentication with OpenID Connect and SAML
+# User authentication with OpenID Connect, SAML and/or Passkeys
 
-TLSPROXY can be configured to authenticate users with OpenID Connect and SAML identity providers.
+TLSPROXY can be configured to authenticate users with OpenID Connect and SAML identity providers. Another option is to use Passkeys for password-less user authentication. To configure Passkeys, users still need to authenticate once with OpenID Connect or SAML, but then authentication is done exclusively with Passkeys.
 
 OpenID Connect has been tested with Google and Facebook as identity providers.
 SAML has been tested with Google Workspace.
@@ -102,3 +102,40 @@ backends:
       - bob@EXAMPLE.COM
       - "@EXAMPLE.COM"   <--- allows anyone from EXAMPLE.COM
 ```
+
+## Passkeys with initial authentication with Google OpenID Connect
+
+```yaml
+oidc:
+- name: google
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth"
+  tokenEndpoint: "https://oauth2.googleapis.com/token"
+  redirectUrl: "https://login.EXAMPLE.COM/oidc/google"
+  clientId: "<YOUR CLIENT ID>"
+  clientSecret: "<YOUR CLIENT SECRET>"
+  domain: "EXAMPLE.COM"
+
+passkey:
+- name: "passkey"
+  identityProvider: "google"
+  endpoint: "https://login.EXAMPLE.COM/passkey"
+  domain: "EXAMPLE.COM"
+
+backends:
+- serverNames:
+  - login.EXAMPLE.COM
+  mode: https
+
+- serverNames:
+  - www.EXAMPLE.COM
+  mode: http
+  addresses:
+  - 192.168.1.1:80
+  sso:
+    provider: passkey
+    acl:
+      - alice@EXAMPLE.COM
+      - bob@EXAMPLE.COM
+      - "@EXAMPLE.COM"   <--- allows anyone from EXAMPLE.COM
+```
+

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	github.com/beevik/etree v1.2.0
 	github.com/c2FmZQ/storage v0.1.0
+	github.com/fxamacker/cbor/v2 v2.5.0
 	github.com/go-test/deep v1.1.0
 	github.com/golang-jwt/jwt/v5 v5.0.0
 	github.com/russellhaering/goxmldsig v1.4.0
@@ -17,6 +18,7 @@ require (
 require (
 	github.com/jonboulle/clockwork v0.4.0 // indirect
 	github.com/stretchr/testify v1.8.4 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/net v0.15.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fxamacker/cbor/v2 v2.5.0 h1:oHsG0V/Q6E/wqTS2O1Cozzsy69nqCiguo5Q1a1ADivE=
+github.com/fxamacker/cbor/v2 v2.5.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
 github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/golang-jwt/jwt/v5 v5.0.0 h1:1n1XNM9hk7O9mnQoNBGolZvzebBQ7p93ULHRc28XJUE=
@@ -34,6 +36,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 golang.org/x/crypto v0.13.0 h1:mvySKfSWJ+UKUii46M40LOvyWfN0s2U+46/jDd0e6Ck=
 golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=
 golang.org/x/net v0.15.0 h1:ugBLEUaxABaB5AJqW9enI0ACdci2RUd4eP51NTBvuJ8=

--- a/main.go
+++ b/main.go
@@ -23,6 +23,9 @@
 
 // tlsproxy is a simple TLS terminating proxy that uses Let's Encrypt to provide
 // TLS encryption for any TCP and HTTP servers.
+//
+// It can also act as a reverse HTTP proxy with optional user authentication
+// with SAML, OpenID Connect, and/or passkeys.
 package main
 
 import (

--- a/proxy/backend-sso.go
+++ b/proxy/backend-sso.go
@@ -71,9 +71,9 @@ func init() {
 	ssoStatusTemplate = template.Must(template.New("sso-status").Parse(ssoStatusEmbed))
 }
 
-func claimsFromCtx(ctx context.Context) jwt.Claims {
+func claimsFromCtx(ctx context.Context) jwt.MapClaims {
 	if v := ctx.Value(authCtxKey); v != nil {
-		return v.(jwt.Claims)
+		return v.(jwt.MapClaims)
 	}
 	return nil
 }
@@ -158,10 +158,7 @@ func (be *Backend) serveSSOStyle(w http.ResponseWriter, req *http.Request) {
 }
 
 func (be *Backend) serveSSOStatus(w http.ResponseWriter, req *http.Request) {
-	var claims jwt.MapClaims
-	if c := claimsFromCtx(req.Context()); c != nil {
-		claims, _ = c.(jwt.MapClaims)
-	}
+	claims := claimsFromCtx(req.Context())
 	var keys []string
 	for k := range claims {
 		keys = append(keys, k)

--- a/proxy/backend.go
+++ b/proxy/backend.go
@@ -212,6 +212,12 @@ func (be *Backend) localHandlersAndAuthz(next http.Handler) http.Handler {
 			h.handler.ServeHTTP(w, req)
 			return
 		}
+		if !exists {
+			if _, ok := be.localHandlers[req.URL.Path+"/"]; ok {
+				http.Redirect(w, req, req.URL.Path+"/", http.StatusMovedPermanently)
+				return
+			}
+		}
 		if next == nil {
 			http.NotFound(w, req)
 			return

--- a/proxy/internal/cookiemanager/cookiemanager.go
+++ b/proxy/internal/cookiemanager/cookiemanager.go
@@ -56,7 +56,7 @@ func New(tm *tokenmanager.TokenManager, provider, domain, issuer string) *Cookie
 	}
 }
 
-func (cm *CookieManager) SetAuthTokenCookie(w http.ResponseWriter, userID, sessionID string, extraClaims map[string]string) error {
+func (cm *CookieManager) SetAuthTokenCookie(w http.ResponseWriter, userID, sessionID string, extraClaims map[string]any) error {
 	now := time.Now().UTC()
 	claims := jwt.MapClaims{
 		"iat":       now.Unix(),

--- a/proxy/internal/cookiemanager/cookiemanager.go
+++ b/proxy/internal/cookiemanager/cookiemanager.go
@@ -57,6 +57,9 @@ func New(tm *tokenmanager.TokenManager, provider, domain, issuer string) *Cookie
 }
 
 func (cm *CookieManager) SetAuthTokenCookie(w http.ResponseWriter, userID, sessionID string, extraClaims map[string]any) error {
+	if userID == "" {
+		return errors.New("userID cannot be empty")
+	}
 	now := time.Now().UTC()
 	claims := jwt.MapClaims{
 		"iat":       now.Unix(),
@@ -160,6 +163,9 @@ func (cm *CookieManager) ValidateAuthTokenCookie(req *http.Request) (*jwt.Token,
 	}
 	if c, ok := tok.Claims.(jwt.MapClaims); !ok || c["proxyauth"] != cm.issuer || c["provider"] != cm.provider {
 		return nil, errors.New("invalid proxyauth or provider")
+	}
+	if sub, err := tok.Claims.GetSubject(); err != nil || sub == "" {
+		return nil, errors.New("invalid subject")
 	}
 	return tok, nil
 }

--- a/proxy/internal/oidc/client.go
+++ b/proxy/internal/oidc/client.go
@@ -65,7 +65,7 @@ type Config struct {
 
 // CookieManager is the interface to set and clear the auth token.
 type CookieManager interface {
-	SetAuthTokenCookie(w http.ResponseWriter, userID, sessionID string, extraClaims map[string]string) error
+	SetAuthTokenCookie(w http.ResponseWriter, userID, sessionID string, extraClaims map[string]any) error
 	ClearCookies(w http.ResponseWriter) error
 }
 
@@ -246,7 +246,7 @@ func (p *ProviderClient) HandleCallback(w http.ResponseWriter, req *http.Request
 		http.Error(w, "email not verified", http.StatusForbidden)
 		return
 	}
-	extraClaims := map[string]string{
+	extraClaims := map[string]any{
 		"source": claims.Issuer,
 	}
 	if claims.Name != "" {

--- a/proxy/internal/passkeys/auth-template.html
+++ b/proxy/internal/passkeys/auth-template.html
@@ -22,19 +22,19 @@
     <a class="button" href="{{.Self}}?get=RegisterNewID&nonce={{.Nonce}}">Register New Identity</a>
 {{- end }}
 {{- if eq .Mode "RegisterNewID" }}
-    <a class="button" onclick="switchAccount();">Pick A Different Identity</a>
-    <a class="button" href="{{.Self}}?get=Login&nonce={{.Nonce}}">Use Existing Passkey</a>
+    <a class="button" onclick="switchAccount({{.Self}}+'?get=Login&nonce={{.Nonce}}');">Switch Account</a>
 {{- end }}
   </div>
   <div id="message">
 {{- if eq .Mode "Login" }}
-    <div><a class="button" onclick="loginWithPasskey({{.RedirectURL}});">Login With Passkey</a></div>
+    <div><a class="button" onclick="loginWithPasskey({{.RedirectURL}});">Login</a></div>
 {{- end }}
 {{- if eq .Mode "RegisterNewID" }}
     <div>{{.Subject}}</div>
   {{- if .IsAllowed }}
     {{- if .IsRegistered }}
     <div>Already Registered</div>
+    <div><a class="button" onclick="loginWithPasskey({{.RedirectURL}});">Login</a></div>
     {{- else }}
     <div><a class="button" onclick="registerPasskey({{.RedirectURL}});">Register This Identity</a></div>
     {{- end }}

--- a/proxy/internal/passkeys/auth-template.html
+++ b/proxy/internal/passkeys/auth-template.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Passkey</title>
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=10, minimum-scale=0.1" />
+<link rel="stylesheet" type="text/css" href="/.sso/style.css" />
+<script src="?get=JS"></script>
+<style>
+#sum {
+  position: fixed;
+  bottom: 10px;
+  width: 100vw;
+  text-align: center;
+}
+</style>
+</head>
+<body>
+  <div id="sum">Access to this page is controlled using <a href="https://fidoalliance.org/passkeys/">Passkeys</a>.</div>
+  <div id="buttons">
+{{- if eq .Mode "Login" }}
+    <a class="button" href="{{.Self}}?get=RegisterNewID&nonce={{.Nonce}}">Register New Identity</a>
+{{- end }}
+{{- if eq .Mode "RegisterNewID" }}
+    <a class="button" href="{{.Self}}?get=Login&nonce={{.Nonce}}">Use Existing Passkey</a>
+{{- end }}
+  </div>
+  <div id="message">
+{{- if eq .Mode "Login" }}
+    <div><a class="button" onclick="loginWithPasskey({{.RedirectURL}});">Login With Passkey</a></div>
+{{- end }}
+{{- if eq .Mode "RegisterNewID" }}
+    <div>{{.Subject}}</div>
+{{- if .IsRegistered }}
+    <div>Already Registered</div>
+{{- else }}
+    <div><a class="button" onclick="registerPasskey({{.RedirectURL}});">Register This Identity</a></div>
+{{- end }}
+{{- end }}
+  </div>
+</body>
+</html>

--- a/proxy/internal/passkeys/auth-template.html
+++ b/proxy/internal/passkeys/auth-template.html
@@ -31,11 +31,15 @@
 {{- end }}
 {{- if eq .Mode "RegisterNewID" }}
     <div>{{.Subject}}</div>
-{{- if .IsRegistered }}
+  {{- if .IsAllowed }}
+    {{- if .IsRegistered }}
     <div>Already Registered</div>
-{{- else }}
+    {{- else }}
     <div><a class="button" onclick="registerPasskey({{.RedirectURL}});">Register This Identity</a></div>
-{{- end }}
+    {{- end }}
+  {{- else }}
+    <div>Is Not Allowed</div>
+  {{- end }}
 {{- end }}
   </div>
 </body>

--- a/proxy/internal/passkeys/auth-template.html
+++ b/proxy/internal/passkeys/auth-template.html
@@ -22,6 +22,7 @@
     <a class="button" href="{{.Self}}?get=RegisterNewID&nonce={{.Nonce}}">Register New Identity</a>
 {{- end }}
 {{- if eq .Mode "RegisterNewID" }}
+    <a class="button" onclick="switchAccount();">Pick A Different Identity</a>
     <a class="button" href="{{.Self}}?get=Login&nonce={{.Nonce}}">Use Existing Passkey</a>
 {{- end }}
   </div>

--- a/proxy/internal/passkeys/manage-template.html
+++ b/proxy/internal/passkeys/manage-template.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Passkey</title>
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=10, minimum-scale=0.1" />
+<link rel="stylesheet" type="text/css" href="/.sso/style.css" />
+<script src="?get=JS"></script>
+<style>
+#subject {
+  padding: 1em;
+}
+#message {
+  width: auto;
+}
+#keys {
+  text-align: left;
+  display: grid;
+  grid-template-columns: auto auto auto auto;
+  gap: 0;
+  padding: 0;
+  border: solid 1px #606060;
+}
+#keys > div {
+  border: solid 1px #404040;
+  margin: 0;
+  padding: 0.25em;
+  white-space: nowrap;
+}
+</style>
+</head>
+<body>
+  <div id="subject">
+  {{ .Subject }}
+  </div>
+  <div id="buttons">
+    <a class="button" onclick="registerPasskey();">Register New Passkey</a>
+  </div>
+  <div id="message">
+    Registered Passkeys
+    <div id="keys">
+      <div>ID</div>
+      <div>Created (UTC)</div>
+      <div>Last Seen (UTC)</div>
+      <div>&nbsp;</div>
+{{- range .Keys }}
+      <div>{{.ShortID}}</div>
+      <div>{{.Created}}</div>
+      <div>{{.LastSeen}}</div>
+      <div>{{ if eq .Hash $.CurrentKey }}(this session){{ else }}<a onclick="deleteKey({{.ID}})">❌</a>{{ end }}</div>
+{{- end }}
+    </div>
+  </div>
+</body>
+</html>

--- a/proxy/internal/passkeys/manager.go
+++ b/proxy/internal/passkeys/manager.go
@@ -384,7 +384,11 @@ func (m *Manager) ManageKeys(w http.ResponseWriter, req *http.Request) {
 	}
 	mode := req.Form.Get("get")
 	subject, _ := claims.GetSubject()
-	passkeyHash := claims.(jwt.MapClaims)["passkey_hash"].(string)
+	passkeyHash, ok := claims.(jwt.MapClaims)["passkey_hash"].(string)
+	if !ok {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
 
 	switch mode {
 	case "AttestationOptions":

--- a/proxy/internal/passkeys/manager.go
+++ b/proxy/internal/passkeys/manager.go
@@ -1,0 +1,766 @@
+// MIT License
+//
+// Copyright (c) 2023 TTBT Enterprises LLC
+// Copyright (c) 2023 Robin Thellend <rthellend@rthellend.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package passkeys
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	_ "embed"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html/template"
+	"io"
+	"log"
+	"maps"
+	"net"
+	"net/http"
+	"net/url"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/c2FmZQ/storage"
+	jwt "github.com/golang-jwt/jwt/v5"
+
+	"github.com/c2FmZQ/tlsproxy/proxy/internal/cookiemanager"
+)
+
+const passkeyFile = "passkeys"
+
+var (
+	//go:embed auth-template.html
+	authEmbed    string
+	authTemplate *template.Template
+	//go:embed manage-template.html
+	manageEmbed    string
+	manageTemplate *template.Template
+	//go:embed webauthn.js
+	webauthnJSEmbed []byte
+)
+
+func init() {
+	authTemplate = template.Must(template.New("passkey-auth").Parse(authEmbed))
+	manageTemplate = template.Must(template.New("passkey-manage").Parse(manageEmbed))
+}
+
+type user struct {
+	Handle Bytes
+	Keys   []*userKey
+	Claims map[string]any
+}
+
+type userKey struct {
+	Name       string
+	ID         Bytes
+	PublicKey  Bytes
+	RPIDHash   Bytes
+	Transports []string
+	CreatedAt  time.Time
+	LastSeen   time.Time
+}
+
+// EventRecorder is used to record events.
+type EventRecorder interface {
+	Record(string)
+}
+
+type Config struct {
+	Store *storage.Storage
+	Other interface {
+		RequestLogin(w http.ResponseWriter, req *http.Request, origURL string)
+	}
+	Endpoint           string
+	EventRecorder      EventRecorder
+	CookieManager      *cookiemanager.CookieManager
+	OtherCookieManager *cookiemanager.CookieManager
+	ClaimsFromCtx      func(context.Context) jwt.Claims
+}
+
+func NewManager(cfg Config) (*Manager, error) {
+	m := &Manager{
+		cfg:        cfg,
+		challenges: make(map[string]*challenge),
+		nonces:     make(map[string]*passkeyData),
+	}
+	m.db.Handles = make(map[string]*user)
+	m.db.Subjects = make(map[string]string)
+	m.cfg.Store.CreateEmptyFile(passkeyFile, &m.db)
+	if err := m.cfg.Store.ReadDataFile(passkeyFile, &m.db); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+type Manager struct {
+	cfg Config
+	db  struct {
+		Handles  map[string]*user
+		Subjects map[string]string
+	}
+
+	mu         sync.Mutex
+	challenges map[string]*challenge
+
+	noncesMu sync.Mutex
+	nonces   map[string]*passkeyData
+}
+
+type challenge struct {
+	created time.Time
+	claims  map[string]any
+	uid     []byte
+}
+
+type passkeyData struct {
+	created time.Time
+	origURL string
+}
+
+func (m *Manager) vacuum() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	now := time.Now().UTC()
+	for k, v := range m.challenges {
+		if v.created.Add(5 * time.Minute).Before(now) {
+			delete(m.challenges, k)
+		}
+	}
+}
+
+func (m *Manager) RequestLogin(w http.ResponseWriter, req *http.Request, origURL string) {
+	m.noncesMu.Lock()
+	defer m.noncesMu.Unlock()
+
+	n := make([]byte, 16)
+	if _, err := io.ReadFull(rand.Reader, n); err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	nonce := hex.EncodeToString(n)
+	m.nonces[nonce] = &passkeyData{
+		created: time.Now().UTC(),
+		origURL: origURL,
+	}
+
+	u, err := url.Parse(m.cfg.Endpoint)
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	ephost := u.Host
+	if h, _, err := net.SplitHostPort(ephost); err == nil {
+		ephost = h
+	}
+	port := ""
+	if _, p, err := net.SplitHostPort(req.Host); err == nil {
+		port = p
+	}
+	if port != "" {
+		ephost = net.JoinHostPort(ephost, port)
+	}
+	args := u.Query()
+	args.Set("get", "Login")
+	args.Set("nonce", nonce)
+	u.Host = ephost
+	u.RawQuery = args.Encode()
+	http.Redirect(w, req, u.String(), http.StatusFound)
+}
+
+func (m *Manager) HandleCallback(w http.ResponseWriter, req *http.Request) {
+	m.noncesMu.Lock()
+	defer m.noncesMu.Unlock()
+	now := time.Now().UTC()
+	for k, v := range m.nonces {
+		if v.created.Add(10 * time.Minute).Before(now) {
+			delete(m.nonces, k)
+		}
+	}
+	req.ParseForm()
+
+	mode := req.Form.Get("get")
+
+	token, err := m.cfg.OtherCookieManager.ValidateAuthTokenCookie(req)
+	if err != nil {
+		switch mode {
+		case "RegisterNewID":
+			req.URL.Scheme = "https"
+			req.URL.Host = req.Host
+			m.cfg.Other.RequestLogin(w, req, req.URL.String())
+			return
+		case "AttestationOptions", "AddKey":
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+	}
+
+	switch mode {
+	case "Login", "RegisterNewID":
+		nonce := req.Form.Get("nonce")
+		d, ok := m.nonces[nonce]
+		if !ok {
+			http.Redirect(w, req, "/", http.StatusFound)
+			return
+		}
+
+		data := struct {
+			Self         string
+			RedirectURL  string
+			Mode         string
+			Nonce        string
+			Subject      string
+			IsRegistered bool
+		}{
+			Self:        req.URL.Path,
+			RedirectURL: d.origURL,
+			Mode:        mode,
+			Nonce:       nonce,
+		}
+		if token != nil {
+			data.Subject, _ = token.Claims.GetSubject()
+			data.IsRegistered = m.subjectIsRegistered(data.Subject)
+		}
+		authTemplate.Execute(w, data)
+
+	case "AssertionOptions":
+		opts, err := m.assertionOptions()
+		if err != nil {
+			log.Printf("ERR assertionOptions: %v", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("content-type", "application/json")
+		json.NewEncoder(w).Encode(opts)
+
+	case "AttestationOptions":
+		claims, ok := token.Claims.(jwt.MapClaims)
+		if !ok {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		opts, err := m.attestationOptions(claims)
+		if err != nil {
+			log.Printf("ERR attestationOptions: %v", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("content-type", "application/json")
+		json.NewEncoder(w).Encode(opts)
+
+	case "Check":
+		if req.Method != "POST" {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		claims, err := m.processAssertion(req.Form.Get("args"))
+		if err != nil {
+			log.Printf("ERR processAssertion: %v", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		m.setAuthToken(w, claims)
+
+	case "AddKey":
+		if req.Method != "POST" {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		claims, ok := token.Claims.(jwt.MapClaims)
+		if !ok {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		if err := m.processAttestation(claims, req.Host, req.Form.Get("args"), false); err != nil {
+			log.Printf("ERR processAttestation: %v", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		m.setAuthToken(w, claims)
+
+	case "JS":
+		serveWebauthnJS(w, req)
+
+	default:
+		http.Error(w, "invalid request", http.StatusBadRequest)
+	}
+}
+
+func serveWebauthnJS(w http.ResponseWriter, req *http.Request) {
+	sum := sha256.Sum256(webauthnJSEmbed)
+	etag := `"` + hex.EncodeToString(sum[:]) + `"`
+
+	w.Header().Set("Content-Type", "text/css")
+	w.Header().Set("Cache-Control", "public")
+	w.Header().Set("Etag", etag)
+
+	if e := req.Header.Get("If-None-Match"); e == etag {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	w.Write(webauthnJSEmbed)
+}
+
+func (m *Manager) ManageKeys(w http.ResponseWriter, req *http.Request) {
+	u, err := url.Parse(m.cfg.Endpoint)
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	ephost := u.Host
+	if h, _, err := net.SplitHostPort(ephost); err == nil {
+		ephost = h
+	}
+	port := ""
+	if _, p, err := net.SplitHostPort(req.Host); err == nil {
+		port = p
+	}
+	if port != "" {
+		ephost = net.JoinHostPort(ephost, port)
+	}
+	if ephost != req.Host {
+		req.URL.Scheme = "https"
+		req.URL.Host = ephost
+		http.Redirect(w, req, req.URL.String(), http.StatusFound)
+		return
+	}
+
+	req.ParseForm()
+	req.URL.Scheme = "https"
+	req.URL.Host = req.Host
+	here := req.URL.String()
+
+	claims := m.cfg.ClaimsFromCtx(req.Context())
+	if claims == nil {
+		m.RequestLogin(w, req, here)
+		return
+	}
+	mode := req.Form.Get("get")
+	subject, _ := claims.GetSubject()
+	passkeyHash := claims.(jwt.MapClaims)["passkey_hash"].(string)
+
+	switch mode {
+	case "AttestationOptions":
+		opts, err := m.attestationOptions(claims.(jwt.MapClaims))
+		if err != nil {
+			log.Printf("ERR attestationOptions: %v", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("content-type", "application/json")
+		json.NewEncoder(w).Encode(opts)
+
+	case "AddKey":
+		if req.Method != "POST" {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		if err := m.processAttestation(claims.(jwt.MapClaims), req.Host, req.Form.Get("args"), true); err != nil {
+			log.Printf("ERR processAttestation: %v", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("content-type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"result": "ok",
+		})
+
+	case "DeleteKey":
+		if req.Method != "POST" {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		id, err := hex.DecodeString(req.Form.Get("id"))
+		if err != nil {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		h := sha256.Sum256(id)
+		if passkeyHash == hex.EncodeToString(h[:]) {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		if err := m.deleteKey(subject, id); err != nil {
+			log.Printf("ERR deleteKey(%q, %v): %v", subject, id, err)
+		}
+		w.Header().Set("content-type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"result": "ok",
+		})
+
+	case "JS":
+		serveWebauthnJS(w, req)
+
+	case "":
+		data := struct {
+			Self       string
+			Mode       string
+			Subject    string
+			Keys       []keyItem
+			CurrentKey string
+		}{
+			Self:       req.URL.Path,
+			Mode:       mode,
+			Subject:    subject,
+			Keys:       m.keys(subject),
+			CurrentKey: passkeyHash,
+		}
+		manageTemplate.Execute(w, data)
+
+	default:
+		http.Error(w, "invalid request", http.StatusBadRequest)
+	}
+}
+
+type keyItem struct {
+	ID       string
+	ShortID  string
+	Hash     string
+	Created  string
+	LastSeen string
+}
+
+func (m *Manager) keys(subject string) []keyItem {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	h, ok := m.db.Subjects[subject]
+	if !ok {
+		return nil
+	}
+	u, ok := m.db.Handles[h]
+	if !ok {
+		return nil
+	}
+	keys := make([]keyItem, len(u.Keys))
+	for i, k := range u.Keys {
+		h := sha256.Sum256(k.ID)
+		ki := keyItem{
+			ID:       hex.EncodeToString(k.ID),
+			ShortID:  hex.EncodeToString(k.ID),
+			Hash:     hex.EncodeToString(h[:]),
+			Created:  k.CreatedAt.Format("2006-01-02 15:04:05"),
+			LastSeen: k.LastSeen.Format("2006-01-02 15:04:05"),
+		}
+		if len(ki.ShortID) > 8 {
+			ki.ShortID = ki.ShortID[:8]
+		}
+		keys[i] = ki
+	}
+	return keys
+}
+
+func (m *Manager) subjectIsRegistered(subject string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	h, ok := m.db.Subjects[subject]
+	if !ok {
+		return false
+	}
+	u, ok := m.db.Handles[h]
+	return ok && len(u.Keys) > 0
+}
+
+func (m *Manager) deleteKey(subject string, id Bytes) (retErr error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	commit, err := m.cfg.Store.OpenForUpdate(passkeyFile, &m.db)
+	if err != nil {
+		return err
+	}
+	defer commit(false, &retErr)
+
+	h, ok := m.db.Subjects[subject]
+	if !ok {
+		return errors.New("not found")
+	}
+	u, ok := m.db.Handles[h]
+	if !ok {
+		return errors.New("not found")
+	}
+	var keys []*userKey
+	for _, k := range u.Keys {
+		if !bytes.Equal(k.ID, id) {
+			keys = append(keys, k)
+		}
+	}
+	u.Keys = keys
+	return commit(true, nil)
+}
+
+func (m *Manager) setAuthToken(w http.ResponseWriter, claims map[string]any) {
+	subject, ok := claims["sub"].(string)
+	if !ok {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	sid, ok := claims["sid"].(string)
+	if !ok {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if err := m.cfg.CookieManager.SetAuthTokenCookie(w, subject, sid, claims); err != nil {
+		log.Printf("ERR SetAuthTokenCookie: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("content-type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"result": "ok",
+	})
+}
+
+func (m *Manager) attestationOptions(claims map[string]any) (*AttestationOptions, error) {
+	m.vacuum()
+	opts, err := newAttestationOptions()
+	if err != nil {
+		return nil, err
+	}
+	subject, ok := claims["sub"].(string)
+	if !ok {
+		return nil, errors.New("invalid subject")
+	}
+	ep, err := url.Parse(m.cfg.Endpoint)
+	if err != nil {
+		return nil, errors.New("internal error")
+	}
+	opts.User.Name = subject
+	opts.User.DisplayName = subject
+	opts.RelyingParty.Name = ep.Host
+	opts.RelyingParty.ID = ep.Host
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if h, ok := m.db.Subjects[subject]; ok {
+		u, ok := m.db.Handles[h]
+		if !ok {
+			return nil, errors.New("internal error")
+		}
+		opts.User.ID = u.Handle
+		for _, key := range u.Keys {
+			opts.ExcludeCredentials = append(opts.ExcludeCredentials, CredentialID{
+				Type:       "public-key",
+				ID:         key.ID,
+				Transports: key.Transports,
+			})
+		}
+	} else {
+		uid := make([]byte, 32)
+		if _, err := io.ReadFull(rand.Reader, uid); err != nil {
+			return nil, err
+		}
+		opts.User.ID = uid
+	}
+
+	m.challenges[base64.RawURLEncoding.EncodeToString(opts.Challenge)] = &challenge{
+		created: time.Now().UTC(),
+		claims:  claims,
+		uid:     opts.User.ID,
+	}
+	return opts, nil
+}
+
+func (m *Manager) processAttestation(claims map[string]any, host, jsargs string, allowNewKey bool) (retErr error) {
+	m.vacuum()
+	subject, ok := claims["sub"].(string)
+	if !ok {
+		return errors.New("invalid subject")
+	}
+	var args struct {
+		ClientDataJSON    Bytes    `json:"clientDataJSON"`
+		AttestationObject Bytes    `json:"attestationObject"`
+		Transports        []string `json:"transports"`
+	}
+	if err := json.Unmarshal([]byte(jsargs), &args); err != nil {
+		return err
+	}
+	cd, err := parseClientData(args.ClientDataJSON)
+	if err != nil {
+		return err
+	}
+	if cd.Type != "webauthn.create" {
+		return errors.New("expected clientData.type")
+	}
+	origin := "https://" + host
+	if cd.Origin != origin {
+		log.Printf("ERR cd.Origin: %q != %q", cd.Origin, origin)
+		return errors.New("expected clientData.origin")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	challenge, ok := m.challenges[cd.Challenge]
+	delete(m.challenges, cd.Challenge)
+
+	if !ok || !reflect.DeepEqual(challenge.claims, claims) {
+		return errors.New("invalid challenge")
+	}
+
+	ao, err := parseAttestationObject(args.AttestationObject)
+	if err != nil {
+		return err
+	}
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	if hash := sha256.Sum256([]byte(host)); subtle.ConstantTimeCompare(ao.AuthData.RPIDHash, hash[:]) != 1 {
+		log.Printf("ERR rpidHash: %v != %v", ao.AuthData.RPIDHash, hash[:])
+		return errors.New("invalid rpIdHash")
+	}
+	if !ao.AuthData.UserPresence {
+		return errors.New("user presence is false")
+	}
+	if !ao.AuthData.UserVerification {
+		return errors.New("user verification is false")
+	}
+	creds := ao.AuthData.AttestedCredentials
+	if creds == nil {
+		return errors.New("no attested credentials")
+	}
+
+	commit, err := m.cfg.Store.OpenForUpdate(passkeyFile, &m.db)
+	if err != nil {
+		return err
+	}
+	defer commit(false, &retErr)
+
+	var u *user
+	if h, ok := m.db.Subjects[subject]; ok {
+		u = m.db.Handles[h]
+	}
+	if u == nil {
+		u = &user{
+			Handle: challenge.uid,
+			Claims: challenge.claims,
+		}
+		uids := base64.RawURLEncoding.EncodeToString(challenge.uid)
+		m.db.Handles[uids] = u
+		m.db.Subjects[subject] = uids
+	}
+	if !allowNewKey && len(u.Keys) > 0 {
+		return errors.New("subject is already registered")
+	}
+	now := time.Now().UTC()
+	u.Keys = append(u.Keys, &userKey{
+		ID:         creds.ID,
+		PublicKey:  creds.COSEKey,
+		RPIDHash:   ao.AuthData.RPIDHash,
+		Transports: args.Transports,
+		CreatedAt:  now,
+		LastSeen:   now,
+	})
+	return commit(true, nil)
+}
+
+func (m *Manager) assertionOptions() (*AssertionOptions, error) {
+	m.vacuum()
+	opts, err := newAssertionOptions()
+	if err != nil {
+		return nil, err
+	}
+	m.challenges[base64.RawURLEncoding.EncodeToString(opts.Challenge)] = &challenge{
+		created: time.Now().UTC(),
+	}
+	return opts, nil
+}
+
+func (m *Manager) processAssertion(jsargs string) (claims map[string]any, retErr error) {
+	m.vacuum()
+	var args struct {
+		ID                string `json:"id"`
+		ClientDataJSON    Bytes  `json:"clientDataJSON"`
+		AuthenticatorData Bytes  `json:"authenticatorData"`
+		Signature         Bytes  `json:"signature"`
+		UserHandle        Bytes  `json:"userHandle"`
+	}
+	if err := json.Unmarshal([]byte(jsargs), &args); err != nil {
+		return nil, err
+	}
+	cd, err := parseClientData(args.ClientDataJSON)
+	if err != nil {
+		return nil, err
+	}
+	if cd.Type != "webauthn.get" {
+		return nil, errors.New("unexpected clientData.type")
+	}
+	var authData authenticatorData
+	if err := parseAuthenticatorData(args.AuthenticatorData, &authData); err != nil {
+		return nil, err
+	}
+	if !authData.UserPresence {
+		return nil, errors.New("UserPresence is false")
+	}
+	if !authData.UserVerification {
+		return nil, errors.New("UserVerification is false")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.challenges[cd.Challenge]; !ok {
+		return nil, errors.New("invalid challenge")
+	}
+	delete(m.challenges, cd.Challenge)
+
+	commit, err := m.cfg.Store.OpenForUpdate(passkeyFile, &m.db)
+	if err != nil {
+		return nil, err
+	}
+	defer commit(false, &retErr)
+
+	u, ok := m.db.Handles[base64.RawURLEncoding.EncodeToString(args.UserHandle)]
+	if !ok {
+		return nil, errors.New("invalid userHandle")
+	}
+	kid, err := base64.RawURLEncoding.DecodeString(args.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	var key *userKey
+	for _, k := range u.Keys {
+		if subtle.ConstantTimeCompare(k.ID, kid) == 1 {
+			key = k
+			break
+		}
+	}
+	if key == nil {
+		return nil, fmt.Errorf("unknown key %v", kid)
+	}
+	if subtle.ConstantTimeCompare(authData.RPIDHash, key.RPIDHash) != 1 {
+		return nil, errors.New("rpIdHash mismatch")
+	}
+	if err := verifySignature(key.PublicKey, args.AuthenticatorData, args.ClientDataJSON, args.Signature); err != nil {
+		return nil, err
+	}
+	key.LastSeen = time.Now().UTC()
+
+	c := maps.Clone(u.Claims)
+	h := sha256.Sum256(key.ID)
+	c["passkey_hash"] = hex.EncodeToString(h[:])
+	return c, commit(true, nil)
+}

--- a/proxy/internal/passkeys/manager.go
+++ b/proxy/internal/passkeys/manager.go
@@ -102,7 +102,7 @@ type Config struct {
 	EventRecorder      EventRecorder
 	CookieManager      *cookiemanager.CookieManager
 	OtherCookieManager *cookiemanager.CookieManager
-	ClaimsFromCtx      func(context.Context) jwt.Claims
+	ClaimsFromCtx      func(context.Context) jwt.MapClaims
 }
 
 func NewManager(cfg Config) (*Manager, error) {
@@ -384,7 +384,7 @@ func (m *Manager) ManageKeys(w http.ResponseWriter, req *http.Request) {
 	}
 	mode := req.Form.Get("get")
 	subject, _ := claims.GetSubject()
-	passkeyHash, ok := claims.(jwt.MapClaims)["passkey_hash"].(string)
+	passkeyHash, ok := claims["passkey_hash"].(string)
 	if !ok {
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
@@ -392,7 +392,7 @@ func (m *Manager) ManageKeys(w http.ResponseWriter, req *http.Request) {
 
 	switch mode {
 	case "AttestationOptions":
-		opts, err := m.attestationOptions(claims.(jwt.MapClaims))
+		opts, err := m.attestationOptions(claims)
 		if err != nil {
 			log.Printf("ERR attestationOptions: %v", err)
 			http.Error(w, "internal error", http.StatusInternalServerError)
@@ -406,7 +406,7 @@ func (m *Manager) ManageKeys(w http.ResponseWriter, req *http.Request) {
 			http.Error(w, "invalid request", http.StatusBadRequest)
 			return
 		}
-		if err := m.processAttestation(claims.(jwt.MapClaims), req.Host, req.Form.Get("args"), true); err != nil {
+		if err := m.processAttestation(claims, req.Host, req.Form.Get("args"), true); err != nil {
 			log.Printf("ERR processAttestation: %v", err)
 			http.Error(w, "internal error", http.StatusInternalServerError)
 			return

--- a/proxy/internal/passkeys/manager.go
+++ b/proxy/internal/passkeys/manager.go
@@ -206,7 +206,7 @@ func (m *Manager) HandleCallback(w http.ResponseWriter, req *http.Request) {
 	defer m.noncesMu.Unlock()
 	now := time.Now().UTC()
 	for k, v := range m.nonces {
-		if v.created.Add(10 * time.Minute).Before(now) {
+		if v.created.Add(time.Hour).Before(now) {
 			delete(m.nonces, k)
 		}
 	}

--- a/proxy/internal/passkeys/manager.go
+++ b/proxy/internal/passkeys/manager.go
@@ -688,6 +688,8 @@ func (m *Manager) assertionOptions() (*AssertionOptions, error) {
 	if err != nil {
 		return nil, err
 	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.challenges[base64.RawURLEncoding.EncodeToString(opts.Challenge)] = &challenge{
 		created: time.Now().UTC(),
 	}

--- a/proxy/internal/passkeys/manager.go
+++ b/proxy/internal/passkeys/manager.go
@@ -155,6 +155,7 @@ func (m *Manager) vacuum() {
 }
 
 func (m *Manager) RequestLogin(w http.ResponseWriter, req *http.Request, origURL string) {
+	m.cfg.EventRecorder.Record("passkey auth request")
 	m.noncesMu.Lock()
 	defer m.noncesMu.Unlock()
 
@@ -284,6 +285,7 @@ func (m *Manager) HandleCallback(w http.ResponseWriter, req *http.Request) {
 			http.Error(w, "internal error", http.StatusInternalServerError)
 			return
 		}
+		m.cfg.EventRecorder.Record("passkey check request")
 		m.setAuthToken(w, claims)
 
 	case "AddKey":
@@ -301,6 +303,7 @@ func (m *Manager) HandleCallback(w http.ResponseWriter, req *http.Request) {
 			http.Error(w, "internal error", http.StatusInternalServerError)
 			return
 		}
+		m.cfg.EventRecorder.Record("passkey addkey request")
 		m.setAuthToken(w, claims)
 
 	case "JS":
@@ -390,6 +393,7 @@ func (m *Manager) ManageKeys(w http.ResponseWriter, req *http.Request) {
 		json.NewEncoder(w).Encode(map[string]string{
 			"result": "ok",
 		})
+		m.cfg.EventRecorder.Record("passkey addkey request")
 
 	case "DeleteKey":
 		if req.Method != "POST" {
@@ -413,6 +417,7 @@ func (m *Manager) ManageKeys(w http.ResponseWriter, req *http.Request) {
 		json.NewEncoder(w).Encode(map[string]string{
 			"result": "ok",
 		})
+		m.cfg.EventRecorder.Record("passkey deletekey request")
 
 	case "JS":
 		serveWebauthnJS(w, req)

--- a/proxy/internal/passkeys/testutils.go
+++ b/proxy/internal/passkeys/testutils.go
@@ -1,0 +1,240 @@
+// MIT License
+//
+// Copyright (c) 2023 TTBT Enterprises LLC
+// Copyright (c) 2023 Robin Thellend <rthellend@thellend.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package passkeys
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+
+	cbor "github.com/fxamacker/cbor/v2"
+)
+
+// FakeAuthenticator mimics the behavior of a WebAuthn authenticator for testing.
+type FakeAuthenticator struct {
+	keys     map[string]fakeAuthKey
+	rpIDHash []byte
+}
+
+type fakeAuthKey struct {
+	id         []byte
+	uid        []byte
+	rk         bool
+	privateKey crypto.Signer
+	signCount  uint32
+}
+
+// NewFakeAuthenticator returns a new FakeAuthenticator for testing.
+func NewFakeAuthenticator() (*FakeAuthenticator, error) {
+	return &FakeAuthenticator{
+		keys: make(map[string]fakeAuthKey),
+	}, nil
+}
+
+// Create mimics the behavior of the WebAuthn create call.
+func (a *FakeAuthenticator) Create(options *AttestationOptions) (clientDataJSON, attestationObject []byte, err error) {
+	var authKey fakeAuthKey
+	var coseKey []byte
+	switch options.PubKeyCredParams[0].Alg {
+	case algES256:
+		privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			return nil, nil, err
+		}
+		if coseKey, err = es256CoseKey(privKey.PublicKey); err != nil {
+			return nil, nil, err
+		}
+		authKey.privateKey = privKey
+	case algRS256:
+		privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			return nil, nil, err
+		}
+		if coseKey, err = rs256CoseKey(privKey.PublicKey); err != nil {
+			return nil, nil, err
+		}
+		authKey.privateKey = privKey
+	default:
+		return nil, nil, errors.New("unexpected options.PubKeyCredParams alg")
+	}
+	cd := clientData{
+		Type:      "webauthn.create",
+		Challenge: base64.RawURLEncoding.EncodeToString(options.Challenge),
+		Origin:    "https://example.com/",
+	}
+	if clientDataJSON, err = json.Marshal(cd); err != nil {
+		return nil, nil, err
+	}
+
+	authKey.uid = options.User.ID
+	authKey.rk = options.AuthenticatorSelection.RequireResidentKey
+
+	authKey.id = make([]byte, 32)
+	if _, err := rand.Read(authKey.id); err != nil {
+		return nil, nil, err
+	}
+	rpIDHash := sha256.Sum256([]byte(options.RelyingParty.ID))
+	a.rpIDHash = rpIDHash[:]
+
+	authData, err := authKey.makeAuthData(a.rpIDHash, coseKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	att := attestation{
+		Format:      "none",
+		RawAuthData: authData,
+	}
+	if attestationObject, err = cbor.Marshal(att); err != nil {
+		return nil, nil, err
+	}
+	a.keys[base64.RawURLEncoding.EncodeToString(authKey.id)] = authKey
+	return
+}
+
+// Get mimics the behavior of the WebAuthn create call.
+func (a *FakeAuthenticator) Get(options *AssertionOptions) (id []byte, clientDataJSON, authData, signature, userHandle []byte, err error) {
+	var authKey fakeAuthKey
+	if len(options.AllowCredentials) > 0 {
+		for _, k := range options.AllowCredentials {
+			if ak, ok := a.keys[base64.RawURLEncoding.EncodeToString(k.ID)]; ok {
+				id = k.ID
+				authKey = ak
+				break
+			}
+		}
+	} else {
+		for kid, key := range a.keys {
+			if key.rk {
+				id, _ = base64.RawURLEncoding.DecodeString(kid)
+				authKey = key
+				userHandle = key.uid
+				break
+			}
+		}
+	}
+	if len(id) == 0 {
+		err = errors.New("key not found")
+		return
+	}
+	cd := clientData{
+		Type:      "webauthn.get",
+		Challenge: base64.RawURLEncoding.EncodeToString(options.Challenge),
+		Origin:    "https://example.com/",
+	}
+	if clientDataJSON, err = json.Marshal(cd); err != nil {
+		return
+	}
+	authKey.signCount++
+	if authData, err = authKey.makeAuthData(a.rpIDHash, nil); err != nil {
+		return
+	}
+	signature, err = sign(authKey, authData, clientDataJSON)
+	return
+}
+
+func (a *FakeAuthenticator) RotateKeys() error {
+	for k, v := range a.keys {
+		privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			return err
+		}
+		v.privateKey = privKey
+		a.keys[k] = v
+	}
+	return nil
+}
+
+func (k *fakeAuthKey) makeAuthData(rpIDHash, coseKey []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	buf.Write(rpIDHash)
+
+	var bits uint8
+	bits |= 1      // UP
+	bits |= 1 << 2 // UV
+	if coseKey != nil {
+		bits |= 1 << 6 // AT
+	}
+	buf.Write([]byte{bits})
+	binary.Write(&buf, binary.BigEndian, k.signCount)
+
+	if coseKey != nil {
+		var aaguid [16]byte
+		buf.Write(aaguid[:])
+		binary.Write(&buf, binary.BigEndian, uint16(len(k.id)))
+		buf.Write(k.id)
+		buf.Write(coseKey)
+	}
+	return buf.Bytes(), nil
+}
+
+// es256CoseKey converts a ECDSA public key to COSE.
+func es256CoseKey(publicKey ecdsa.PublicKey) ([]byte, error) {
+	if publicKey.Curve != elliptic.P256() {
+		return nil, errors.New("unexpected EC curve")
+	}
+	ecKey := struct {
+		KTY   int    `cbor:"1,keyasint"`
+		ALG   int    `cbor:"3,keyasint"`
+		Curve int    `cbor:"-1,keyasint"`
+		X     []byte `cbor:"-2,keyasint"`
+		Y     []byte `cbor:"-3,keyasint"`
+	}{
+		KTY:   2,
+		ALG:   algES256,
+		Curve: 1, // P-256
+		X:     publicKey.X.Bytes(),
+		Y:     publicKey.Y.Bytes(),
+	}
+	return cbor.Marshal(ecKey)
+}
+
+// rs256CoseKey converts a RSA public key to COSE.
+func rs256CoseKey(publicKey rsa.PublicKey) ([]byte, error) {
+	rsaKey := struct {
+		KTY int    `cbor:"1,keyasint"`
+		ALG int    `cbor:"3,keyasint"`
+		N   []byte `cbor:"-1,keyasint"`
+		E   int    `cbor:"-2,keyasint"`
+	}{
+		KTY: 3,
+		ALG: algRS256,
+		N:   publicKey.N.Bytes(),
+		E:   publicKey.E,
+	}
+	return cbor.Marshal(rsaKey)
+}
+
+func sign(authKey fakeAuthKey, authData, clientDataJSON []byte) ([]byte, error) {
+	signedBytes := signedBytes(authData, clientDataJSON)
+	hashed := sha256.Sum256(signedBytes)
+	return authKey.privateKey.Sign(rand.Reader, hashed[:], crypto.SHA256)
+}

--- a/proxy/internal/passkeys/testutils.go
+++ b/proxy/internal/passkeys/testutils.go
@@ -43,6 +43,7 @@ import (
 type FakeAuthenticator struct {
 	keys     map[string]fakeAuthKey
 	rpIDHash []byte
+	origin   string
 }
 
 type fakeAuthKey struct {
@@ -56,8 +57,13 @@ type fakeAuthKey struct {
 // NewFakeAuthenticator returns a new FakeAuthenticator for testing.
 func NewFakeAuthenticator() (*FakeAuthenticator, error) {
 	return &FakeAuthenticator{
-		keys: make(map[string]fakeAuthKey),
+		keys:   make(map[string]fakeAuthKey),
+		origin: "https://example.com/",
 	}, nil
+}
+
+func (a *FakeAuthenticator) SetOrigin(orig string) {
+	a.origin = orig
 }
 
 // Create mimics the behavior of the WebAuthn create call.
@@ -89,7 +95,7 @@ func (a *FakeAuthenticator) Create(options *AttestationOptions) (clientDataJSON,
 	cd := clientData{
 		Type:      "webauthn.create",
 		Challenge: base64.RawURLEncoding.EncodeToString(options.Challenge),
-		Origin:    "https://example.com/",
+		Origin:    a.origin,
 	}
 	if clientDataJSON, err = json.Marshal(cd); err != nil {
 		return nil, nil, err

--- a/proxy/internal/passkeys/webauthn.go
+++ b/proxy/internal/passkeys/webauthn.go
@@ -1,0 +1,349 @@
+// MIT License
+//
+// Copyright (c) 2023 TTBT Enterprises LLC
+// Copyright (c) 2023 Robin Thellend <rthellend@thellend.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Package passkeys implements the server side of WebAuthn.
+package passkeys
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+
+	cbor "github.com/fxamacker/cbor/v2"
+)
+
+const (
+	// https://w3c.github.io/webauthn/#sctn-alg-identifier
+	algES256 = -7
+	algRS256 = -257
+)
+
+// errTooShort indicates that the message is too short and can't be decoded.
+var errTooShort = errors.New("too short")
+
+type Bytes []byte
+
+func (b Bytes) MarshalJSON() ([]byte, error) {
+	if b == nil {
+		return []byte("null"), nil
+	}
+	return []byte(strings.Join(strings.Fields(fmt.Sprintf("%d", b)), ",")), nil
+}
+
+// AttestationOptions encapsulates the options to navigator.credentials.create().
+type AttestationOptions struct {
+	// The cryptographic challenge is 32 random bytes.
+	Challenge Bytes `json:"challenge"`
+	// The name of the relying party. The ID is optional.
+	RelyingParty struct {
+		Name string `json:"name"`
+		ID   string `json:"id,omitempty"`
+	} `json:"rp"`
+	// The user information.
+	User struct {
+		ID          Bytes  `json:"id"`
+		Name        string `json:"name"`
+		DisplayName string `json:"displayName"`
+	} `json:"user"`
+	// The acceptable public key params.
+	PubKeyCredParams []PubKeyCredParam `json:"pubKeyCredParams,omitempty"`
+	// Timeout in milliseconds.
+	Timeout int `json:"timeout,omitempty"`
+	// A list of credentials already registered for this user.
+	ExcludeCredentials []CredentialID `json:"excludeCredentials,omitempty"`
+	// The type of attestation
+	Attestation string `json:"attestation,omitempty"`
+	// Authticator selection parameters.
+	AuthenticatorSelection struct {
+		// required, preferred, or discouraged
+		UserVerification string `json:"userVerification"`
+		// Whether we want discoverable credentials.
+		RequireResidentKey bool `json:"requireResidentKey"`
+	} `json:"authenticatorSelection"`
+	// Extensions.
+	Extensions map[string]interface{} `json:"extensions,omitempty"`
+}
+
+// newAttestationOptions returns a new AttestationOptions with Challenge,
+// PubKeyCredParams, and Timeout already populated.
+func newAttestationOptions() (*AttestationOptions, error) {
+	ao := &AttestationOptions{
+		PubKeyCredParams: []PubKeyCredParam{
+			{
+				Type: "public-key",
+				Alg:  algES256,
+			},
+			{
+				Type: "public-key",
+				Alg:  algRS256,
+			},
+		},
+		Timeout: 120000, // 120 sec
+		// No needed with passkeys.
+		Attestation: "none",
+	}
+	ao.AuthenticatorSelection.UserVerification = "required"
+	ao.AuthenticatorSelection.RequireResidentKey = true
+
+	challenge := make([]byte, 32)
+	if _, err := rand.Read(challenge); err != nil {
+		return nil, err
+	}
+	ao.Challenge = challenge
+	return ao, nil
+}
+
+// AssertionOptions encapsulates the options to navigator.credentials.get().
+type AssertionOptions struct {
+	// The cryptographic challenge is 32 random bytes.
+	Challenge Bytes `json:"challenge"`
+	// Timeout in milliseconds.
+	Timeout int `json:"timeout,omitempty"`
+	// A list of credentials already registered for this user.
+	AllowCredentials []CredentialID `json:"allowCredentials"`
+	// UserVerification: required, preferred, discouraged
+	UserVerification string `json:"userVerification"`
+}
+
+// newAssertionOptions returns a new AssertionOptions with Challenge,
+// and Timeout already populated.
+func newAssertionOptions() (*AssertionOptions, error) {
+	ao := &AssertionOptions{
+		Timeout:          120000, // 120 sec
+		UserVerification: "required",
+		AllowCredentials: make([]CredentialID, 0),
+	}
+	challenge := make([]byte, 32)
+	if _, err := rand.Read(challenge); err != nil {
+		return nil, err
+	}
+	ao.Challenge = challenge
+	return ao, nil
+}
+
+// PubKeyCredParam: Public key credential parameters.
+type PubKeyCredParam struct {
+	// The type of credentials. Always "public-key"
+	Type string `json:"type"`
+	// The encryption algorythm: -7 for ES256, -257 for RS256.
+	Alg int `json:"alg"`
+}
+
+// CredentialID is a credential ID from an anthenticator.
+type CredentialID struct {
+	// The type of credentials. Always "public-key"
+	Type string `json:"type"`
+	// The credential ID.
+	ID Bytes `json:"id"`
+	// The available transports for this credential.
+	Transports []string `json:"transports,omitempty"`
+}
+
+// clientData is a decoded ClientDataJSON object.
+type clientData struct {
+	Type      string `json:"type"`
+	Challenge string `json:"challenge"`
+	Origin    string `json:"origin"`
+}
+
+// attestation. https://w3c.github.io/webauthn/#sctn-attestation
+type attestation struct {
+	Format      string          `cbor:"fmt"`
+	AttStmt     cbor.RawMessage `cbor:"attStmt"`
+	RawAuthData []byte          `cbor:"authData"`
+
+	AuthData authenticatorData `cbor:"-"`
+}
+
+// authenticatorData is the authenticator data provided during attestation and
+// assertion. https://w3c.github.io/webauthn/#sctn-authenticator-data
+type authenticatorData struct {
+	RPIDHash               Bytes                `json:"rpIdHash"`
+	UserPresence           bool                 `json:"up"`
+	BackupEligible         bool                 `json:"be"`
+	BackupState            bool                 `json:"bs"`
+	UserVerification       bool                 `json:"uv"`
+	AttestedCredentialData bool                 `json:"at"`
+	ExtensionData          bool                 `json:"ed"`
+	SignCount              uint32               `json:"signCount"`
+	AttestedCredentials    *attestedCredentials `json:"attestedCredentialData"`
+}
+
+// attestedCredentials. https://w3c.github.io/webauthn/#sctn-attested-credential-data
+type attestedCredentials struct {
+	AAGUID  Bytes `json:"AAGUID"`
+	ID      Bytes `json:"credentialId"`
+	COSEKey Bytes `json:"credentialPublicKey"`
+}
+
+// parseAttestationObject parses an attestationObject. Passkeys don't typically
+// provide attestation statements.
+func parseAttestationObject(attestationObject []byte) (*attestation, error) {
+	var att attestation
+	if err := cbor.Unmarshal(attestationObject, &att); err != nil {
+		return nil, fmt.Errorf("cbor.Unmarshal: %w", err)
+	}
+	if err := parseAuthenticatorData(att.RawAuthData, &att.AuthData); err != nil {
+		return nil, fmt.Errorf("parseAuthenticatorData: %w", err)
+	}
+	return &att, nil
+}
+
+func parseAuthenticatorData(raw []byte, ad *authenticatorData) error {
+	// https://w3c.github.io/webauthn/#sctn-authenticator-data
+	if len(raw) < 37 {
+		return errTooShort
+	}
+	ad.RPIDHash = raw[:32]
+	raw = raw[32:]
+	ad.UserPresence = raw[0]&1 != 0
+	ad.UserVerification = (raw[0]>>2)&1 != 0
+	ad.BackupEligible = (raw[0]>>3)&1 != 0
+	ad.BackupState = (raw[0]>>4)&1 != 0
+	ad.AttestedCredentialData = (raw[0]>>6)&1 != 0
+	ad.ExtensionData = (raw[0]>>7)&1 != 0
+	raw = raw[1:]
+	ad.SignCount = binary.BigEndian.Uint32(raw[:4])
+	raw = raw[4:]
+
+	if ad.AttestedCredentialData {
+		// https://w3c.github.io/webauthn/#sctn-attested-credential-data
+		if len(raw) < 18 {
+			return errTooShort
+		}
+		ad.AttestedCredentials = &attestedCredentials{}
+		ad.AttestedCredentials.AAGUID = raw[:16]
+		raw = raw[16:]
+
+		sz := binary.BigEndian.Uint16(raw[:2])
+		raw = raw[2:]
+		if sz > 1023 {
+			return errors.New("invalid credentialId length")
+		}
+		if len(raw) < int(sz) {
+			return errTooShort
+		}
+		ad.AttestedCredentials.ID = raw[:int(sz)]
+		raw = raw[int(sz):]
+
+		var coseKey cbor.RawMessage
+		if err := cbor.Unmarshal(raw, &coseKey); err != nil {
+			return err
+		}
+		ad.AttestedCredentials.COSEKey = Bytes(coseKey)
+	}
+	if ad.ExtensionData {
+		// Parse extensions
+	}
+	return nil
+}
+
+func parseClientData(js []byte) (*clientData, error) {
+	var out clientData
+	err := json.Unmarshal(js, &out)
+	return &out, err
+}
+
+func signedBytes(authData, clientDataJSON []byte) []byte {
+	clientDataHash := sha256.Sum256(clientDataJSON)
+	signedBytes := make([]byte, len(authData)+len(clientDataHash))
+	copy(signedBytes, authData)
+	copy(signedBytes[len(authData):], clientDataHash[:])
+	return signedBytes
+}
+
+// verifySignature verifies the webauthn signature.
+func verifySignature(coseKey, authData, clientDataJSON, signature Bytes) error {
+	signedBytes := signedBytes(authData, clientDataJSON)
+	hashed := sha256.Sum256(signedBytes)
+
+	var kty struct {
+		KTY int `cbor:"1,keyasint"`
+	}
+	if err := cbor.Unmarshal(coseKey, &kty); err != nil {
+		return fmt.Errorf("cbor.Unmarshal(%v): %w", coseKey, err)
+	}
+	switch kty.KTY {
+	case 2: // ECDSA public key
+		var ecKey struct {
+			KTY   int    `cbor:"1,keyasint"`
+			ALG   int    `cbor:"3,keyasint"`
+			Curve int    `cbor:"-1,keyasint"`
+			X     []byte `cbor:"-2,keyasint"`
+			Y     []byte `cbor:"-3,keyasint"`
+		}
+		if err := cbor.Unmarshal(coseKey, &ecKey); err != nil {
+			return err
+		}
+		if ecKey.ALG != algES256 {
+			return errors.New("unexpected EC key alg")
+		}
+		if ecKey.Curve != 1 { // P-256
+			return errors.New("unexpected EC key curve")
+		}
+		publicKey := &ecdsa.PublicKey{
+			Curve: elliptic.P256(),
+			X:     new(big.Int).SetBytes(ecKey.X),
+			Y:     new(big.Int).SetBytes(ecKey.Y),
+		}
+		if !publicKey.Curve.IsOnCurve(publicKey.X, publicKey.Y) {
+			return errors.New("invalid public key")
+		}
+		if !ecdsa.VerifyASN1(publicKey, hashed[:], signature) {
+			return errors.New("invalid signature")
+		}
+		return nil
+	case 3: // RSA public key, RSASSA-PKCS1-v1_5
+		var rsaKey struct {
+			KTY int    `cbor:"1,keyasint"`
+			ALG int    `cbor:"3,keyasint"`
+			N   []byte `cbor:"-1,keyasint"`
+			E   int    `cbor:"-2,keyasint"`
+		}
+		if err := cbor.Unmarshal(coseKey, &rsaKey); err != nil {
+			return err
+		}
+		if rsaKey.ALG != algRS256 {
+			return errors.New("unexpected RSA key alg")
+		}
+		publicKey := &rsa.PublicKey{
+			N: new(big.Int).SetBytes(rsaKey.N),
+			E: rsaKey.E,
+		}
+		if err := rsa.VerifyPKCS1v15(publicKey, crypto.SHA256, hashed[:], signature); err != nil {
+			return err
+		}
+		return nil
+	default:
+		return errors.New("unsupported key type")
+	}
+}

--- a/proxy/internal/passkeys/webauthn.js
+++ b/proxy/internal/passkeys/webauthn.js
@@ -1,0 +1,174 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 TTBT Enterprises LLC
+ * Copyright (c) 2023 Robin Thellend <rthellend@rthellend.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+const self = window.location.pathname;
+
+function registerPasskey(redirectUrl) {
+  if (!('PublicKeyCredential' in window)) {
+    throw new Error('Browser doesn\'t support WebAuthn');
+  }
+
+  fetch(self+'?get=AttestationOptions')
+  .then(resp => {
+    if (resp.status !== 200) {
+      throw resp.status;
+    }
+    return resp.json();
+  })
+  .then(options => {
+    options.challenge = new Uint8Array(options.challenge);
+    if (options.excludeCredentials) {
+      for (let i = 0; i < options.excludeCredentials.length; i++) {
+        options.excludeCredentials[i].id = new Uint8Array(options.excludeCredentials[i].id);
+      }
+    }
+    options.user.id = new Uint8Array(options.user.id);
+    return navigator.credentials.create({publicKey: options});
+  })
+  .then(pkc => {
+    if (pkc.type !== 'public-key' || !(pkc.response instanceof window.AuthenticatorAttestationResponse)) {
+      throw new Error('invalid credentials.create response');
+    }
+    const v = JSON.stringify({
+      clientDataJSON: Array.from(new Uint8Array(pkc.response.clientDataJSON)),
+      attestationObject: Array.from(new Uint8Array(pkc.response.attestationObject)),
+      transports: pkc.response.getTransports(),
+    });
+    return fetch(self+'?get=AddKey', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      body: 'args=' + encodeURIComponent(v),
+    });
+  })
+  .then(resp => {
+    if (resp.status !== 200) {
+      throw resp.status;
+    }
+    return resp.json();
+  })
+  .then(r => {
+    if (r.result === 'ok') {
+      console.log('Success');
+      if (redirectUrl) {
+        window.location = redirectUrl;
+      } else {
+        window.location.reload();
+      }
+    }
+  })
+  .catch(err => {
+    console.log('Failure', err);
+    alert(err);
+  });
+}
+
+function loginWithPasskey(redirectUrl) {
+  if (!('PublicKeyCredential' in window)) {
+    throw new Error('Browser doesn\'t support WebAuthn');
+  }
+  fetch(self+'?get=AssertionOptions')
+  .then(resp => {
+    if (resp.status !== 200) {
+      throw resp.status;
+    }
+    return resp.json();
+  })
+  .then(options => {
+    options.challenge = new Uint8Array(options.challenge);
+    return navigator.credentials.get({publicKey: options})
+  })
+  .then(pkc => {
+    if (pkc.type !== 'public-key' || !(pkc.response instanceof window.AuthenticatorAssertionResponse)) {
+      throw new Error('invalid PublicKeyCredential value');
+    }
+    const v = JSON.stringify({
+        id: pkc.id,
+        clientDataJSON: Array.from(new Uint8Array(pkc.response.clientDataJSON)),
+        authenticatorData: Array.from(new Uint8Array(pkc.response.authenticatorData)),
+        signature: Array.from(new Uint8Array(pkc.response.signature)),
+        userHandle: Array.from(new Uint8Array(pkc.response.userHandle)),
+    });
+    return fetch(self+'?get=Check', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      credentials: 'same-origin',
+      body: 'args=' + encodeURIComponent(v),
+    });
+  })
+  .then(resp => {
+    if (resp.status !== 200) {
+      throw resp.status;
+    }
+    return resp.json();
+  })
+  .then(r => {
+    if (r.result === 'ok') {
+      console.log('Success');
+      if (redirectUrl) {
+        window.location = redirectUrl;
+      } else {
+        window.location.reload();
+      }
+    }
+  })
+  .catch(err => {
+    console.log('Failure', err);
+    alert(err);
+  });
+}
+
+function deleteKey(id) {
+  if (!window.confirm('Delete key ID ' + id + '?')) {
+    return;
+  }
+  fetch(self+'?get=DeleteKey', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded',
+    },
+      body: 'id=' + encodeURIComponent(id),
+  })
+  .then(resp => {
+    if (resp.status !== 200) {
+      throw resp.status;
+    }
+    return resp.json();
+  })
+  .then(r => {
+    if (r.result === 'ok') {
+      console.log('Success');
+      window.location.reload();
+    }
+  })
+  .catch(err => {
+    console.log('Failure', err);
+    alert(err);
+  });
+}
+

--- a/proxy/internal/passkeys/webauthn.js
+++ b/proxy/internal/passkeys/webauthn.js
@@ -173,7 +173,7 @@ function deleteKey(id) {
 }
 
 
-function switchAccount() {
+function switchAccount(redirectUrl) {
   fetch(self+'?get=Switch', {
     method: 'POST',
   })
@@ -186,7 +186,11 @@ function switchAccount() {
   .then(r => {
     if (r.result === 'ok') {
       console.log('Success');
-      window.location.reload();
+      if (redirectUrl) {
+        window.location = redirectUrl;
+      } else {
+        window.location.reload();
+      }
     }
   })
   .catch(err => {

--- a/proxy/internal/passkeys/webauthn.js
+++ b/proxy/internal/passkeys/webauthn.js
@@ -172,3 +172,26 @@ function deleteKey(id) {
   });
 }
 
+
+function switchAccount() {
+  fetch(self+'?get=Switch', {
+    method: 'POST',
+  })
+  .then(resp => {
+    if (resp.status !== 200) {
+      throw resp.status;
+    }
+    return resp.json();
+  })
+  .then(r => {
+    if (r.result === 'ok') {
+      console.log('Success');
+      window.location.reload();
+    }
+  })
+  .catch(err => {
+    console.log('Failure', err);
+    alert(err);
+  });
+}
+

--- a/proxy/internal/passkeys/webauthn_test.go
+++ b/proxy/internal/passkeys/webauthn_test.go
@@ -1,0 +1,229 @@
+// MIT License
+//
+// Copyright (c) 2023 TTBT Enterprises LLC
+// Copyright (c) 2023 Robin Thellend <rthellend@thellend.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package passkeys
+
+import (
+	"bytes"
+	"encoding/base64"
+	"testing"
+)
+
+func TestWithRawBrowserData(t *testing.T) {
+	var (
+		clientDataJSON = []byte{
+			123, 34, 116, 121, 112, 101, 34, 58, 34, 119, 101, 98, 97, 117,
+			116, 104, 110, 46, 99, 114, 101, 97, 116, 101, 34, 44, 34, 99,
+			104, 97, 108, 108, 101, 110, 103, 101, 34, 58, 34, 65, 65, 69,
+			67, 65, 119, 81, 70, 66, 103, 99, 73, 67, 81, 111, 76, 68, 65,
+			48, 79, 68, 120, 65, 82, 69, 104, 77, 85, 70, 82, 89, 88, 71,
+			66, 107, 97, 71, 120, 119, 100, 72, 104, 56, 34, 44, 34, 111,
+			114, 105, 103, 105, 110, 34, 58, 34, 104, 116, 116, 112, 115,
+			58, 47, 47, 112, 102, 102, 116, 46, 110, 101, 116, 34, 44, 34,
+			99, 114, 111, 115, 115, 79, 114, 105, 103, 105, 110, 34, 58,
+			102, 97, 108, 115, 101, 125,
+		}
+		attestationObject = []byte{
+			163, 99, 102, 109, 116, 104, 102, 105, 100, 111, 45, 117, 50,
+			102, 103, 97, 116, 116, 83, 116, 109, 116, 162, 99, 115, 105,
+			103, 88, 72, 48, 70, 2, 33, 0, 206, 172, 115, 184, 201, 72,
+			130, 231, 198, 68, 49, 220, 200, 94, 115, 84, 183, 223, 223,
+			181, 86, 213, 152, 52, 204, 47, 46, 74, 28, 21, 243, 55, 2,
+			33, 0, 197, 18, 140, 110, 215, 146, 61, 20, 119, 12, 229, 155,
+			85, 28, 105, 90, 24, 65, 106, 52, 231, 210, 69, 46, 62, 212,
+			189, 240, 120, 50, 131, 35, 99, 120, 53, 99, 129, 89, 1, 221,
+			48, 130, 1, 217, 48, 130, 1, 125, 160, 3, 2, 1, 2, 2, 1, 1, 48,
+			13, 6, 9, 42, 134, 72, 134, 247, 13, 1, 1, 11, 5, 0, 48, 96,
+			49, 11, 48, 9, 6, 3, 85, 4, 6, 19, 2, 85, 83, 49, 17, 48, 15, 6,
+			3, 85, 4, 10, 12, 8, 67, 104, 114, 111, 109, 105, 117, 109, 49,
+			34, 48, 32, 6, 3, 85, 4, 11, 12, 25, 65, 117, 116, 104, 101,
+			110, 116, 105, 99, 97, 116, 111, 114, 32, 65, 116, 116, 101,
+			115, 116, 97, 116, 105, 111, 110, 49, 26, 48, 24, 6, 3, 85, 4,
+			3, 12, 17, 66, 97, 116, 99, 104, 32, 67, 101, 114, 116, 105,
+			102, 105, 99, 97, 116, 101, 48, 30, 23, 13, 49, 55, 48, 55, 49,
+			52, 48, 50, 52, 48, 48, 48, 90, 23, 13, 52, 50, 49, 49, 49, 55,
+			50, 49, 52, 49, 49, 52, 90, 48, 96, 49, 11, 48, 9, 6, 3, 85, 4,
+			6, 19, 2, 85, 83, 49, 17, 48, 15, 6, 3, 85, 4, 10, 12, 8, 67,
+			104, 114, 111, 109, 105, 117, 109, 49, 34, 48, 32, 6, 3, 85, 4,
+			11, 12, 25, 65, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116,
+			111, 114, 32, 65, 116, 116, 101, 115, 116, 97, 116, 105, 111,
+			110, 49, 26, 48, 24, 6, 3, 85, 4, 3, 12, 17, 66, 97, 116, 99,
+			104, 32, 67, 101, 114, 116, 105, 102, 105, 99, 97, 116, 101, 48,
+			89, 48, 19, 6, 7, 42, 134, 72, 206, 61, 2, 1, 6, 8, 42, 134, 72,
+			206, 61, 3, 1, 7, 3, 66, 0, 4, 141, 97, 126, 101, 201, 80, 142,
+			100, 188, 197, 103, 58, 200, 42, 103, 153, 218, 60, 20, 70, 104,
+			44, 37, 140, 70, 63, 255, 223, 88, 223, 210, 250, 62, 108, 55,
+			139, 83, 215, 149, 196, 164, 223, 251, 65, 153, 237, 215, 134,
+			47, 35, 171, 175, 2, 3, 180, 184, 145, 27, 160, 86, 153, 148,
+			225, 1, 163, 37, 48, 35, 48, 12, 6, 3, 85, 29, 19, 1, 1, 255, 4,
+			2, 48, 0, 48, 19, 6, 11, 43, 6, 1, 4, 1, 130, 229, 28, 2, 1, 1,
+			4, 4, 3, 2, 5, 32, 48, 13, 6, 9, 42, 134, 72, 134, 247, 13, 1,
+			1, 11, 5, 0, 3, 71, 0, 48, 68, 2, 32, 110, 49, 252, 55, 238,
+			119, 141, 29, 27, 125, 75, 232, 103, 146, 197, 2, 229, 163, 237,
+			228, 90, 129, 140, 198, 130, 105, 199, 28, 196, 46, 25, 4, 2,
+			32, 127, 75, 238, 41, 183, 177, 29, 102, 154, 202, 191, 189,
+			245, 16, 158, 46, 24, 96, 245, 180, 107, 134, 72, 16, 46, 227,
+			198, 14, 141, 214, 38, 149, 104, 97, 117, 116, 104, 68, 97, 116,
+			97, 88, 164, 59, 173, 244, 133, 130, 181, 29, 207, 214, 72, 18,
+			138, 31, 63, 249, 128, 104, 87, 82, 35, 83, 189, 56, 165, 215,
+			183, 249, 127, 162, 220, 237, 110, 65, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 221, 85, 140, 104,
+			176, 38, 21, 82, 83, 107, 113, 146, 112, 106, 158, 15, 37, 108,
+			181, 127, 53, 192, 192, 7, 212, 230, 215, 151, 243, 175, 222,
+			88, 165, 1, 2, 3, 38, 32, 1, 33, 88, 32, 80, 137, 11, 175, 56,
+			246, 27, 157, 96, 74, 188, 102, 243, 100, 218, 2, 99, 10, 241,
+			171, 76, 122, 90, 50, 33, 210, 174, 194, 242, 198, 21, 139, 34,
+			88, 32, 207, 17, 25, 199, 194, 225, 116, 13, 169, 195, 3, 52,
+			180, 2, 215, 135, 212, 172, 5, 237, 7, 61, 217, 21, 209, 39,
+			126, 139, 30, 104, 99, 242,
+		}
+		clientDataJSON2 = []byte{
+			123, 34, 116, 121, 112, 101, 34, 58, 34, 119, 101, 98, 97, 117,
+			116, 104, 110, 46, 103, 101, 116, 34, 44, 34, 99, 104, 97, 108,
+			108, 101, 110, 103, 101, 34, 58, 34, 65, 65, 69, 67, 65, 119, 81,
+			70, 66, 103, 99, 73, 67, 81, 111, 76, 68, 65, 48, 79, 68, 120,
+			65, 82, 69, 104, 77, 85, 70, 82, 89, 88, 71, 66, 107, 97, 71,
+			120, 119, 100, 72, 104, 56, 34, 44, 34, 111, 114, 105, 103, 105,
+			110, 34, 58, 34, 104, 116, 116, 112, 115, 58, 47, 47, 112, 102,
+			102, 116, 46, 110, 101, 116, 34, 44, 34, 99, 114, 111, 115, 115,
+			79, 114, 105, 103, 105, 110, 34, 58, 102, 97, 108, 115, 101, 125,
+		}
+		authenticatorData = []byte{
+			59, 173, 244, 133, 130, 181, 29, 207, 214, 72, 18, 138, 31, 63,
+			249, 128, 104, 87, 82, 35, 83, 189, 56, 165, 215, 183, 249, 127,
+			162, 220, 237, 110, 1, 0, 0, 0, 2,
+		}
+		signature = []byte{
+			48, 68, 2, 32, 21, 41, 57, 157, 176, 112, 230, 228, 91, 125, 8,
+			141, 56, 88, 109, 132, 34, 221, 245, 158, 45, 197, 234, 38, 61,
+			70, 234, 31, 104, 115, 184, 198, 2, 32, 42, 99, 185, 185, 22,
+			58, 251, 37, 98, 223, 206, 117, 40, 60, 227, 199, 58, 194, 97,
+			216, 252, 247, 201, 218, 18, 237, 37, 133, 159, 252, 176, 145,
+		}
+	)
+
+	if _, err := parseClientData(clientDataJSON); err != nil {
+		t.Fatalf("parseClientData: %v", err)
+	}
+	if _, err := parseClientData(clientDataJSON2); err != nil {
+		t.Fatalf("parseClientData: %v", err)
+	}
+	ao, err := parseAttestationObject(attestationObject)
+	if err != nil {
+		t.Fatalf("parseAttestationObject: %v", err)
+	}
+	if !ao.AuthData.UserPresence {
+		t.Error("Expected UserPresence to be true")
+	}
+	if ao.AuthData.UserVerification {
+		t.Error("Expected UserVerification to be false")
+	}
+	if ao.AuthData.AttestedCredentials == nil {
+		t.Fatal("no AttestedCredentials")
+	}
+	if err := verifySignature(ao.AuthData.AttestedCredentials.COSEKey, authenticatorData, clientDataJSON2, signature); err != nil {
+		t.Fatalf("verifySignature: %v", err)
+	}
+}
+
+func TestWithFakeAuthenticator(t *testing.T) {
+	auth, err := NewFakeAuthenticator()
+	if err != nil {
+		t.Fatalf("NewFakeAuthenticator: %v", err)
+	}
+	attestOpts, err := newAttestationOptions()
+	if err != nil {
+		t.Fatalf("newAttestationOptions: %v", err)
+	}
+	keys := make(map[string]Bytes)
+	for _, alg := range []int{algES256, algRS256} {
+		attestOpts.PubKeyCredParams = []PubKeyCredParam{
+			{
+				Type: "public-key",
+				Alg:  alg,
+			},
+		}
+		_, attestationObject, err := auth.Create(attestOpts)
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		ao, err := parseAttestationObject(attestationObject)
+		if err != nil {
+			t.Fatalf("parseAttestationObject: %v", err)
+		}
+		if !ao.AuthData.UserPresence {
+			t.Error("Expected UserPresence to be true")
+		}
+		if !ao.AuthData.UserVerification {
+			t.Error("Expected UserVerification to be true")
+		}
+		if ao.AuthData.AttestedCredentials == nil {
+			t.Fatal("no AttestedCredentials")
+		}
+		keys[base64.RawURLEncoding.EncodeToString(ao.AuthData.AttestedCredentials.ID)] = ao.AuthData.AttestedCredentials.COSEKey
+	}
+
+	for keyID, coseKey := range keys {
+		assertOpts, err := newAssertionOptions()
+		if err != nil {
+			t.Fatalf("newAssertionOptions: %v", err)
+		}
+		kid, _ := base64.RawURLEncoding.DecodeString(keyID)
+		assertOpts.AllowCredentials = append(assertOpts.AllowCredentials, CredentialID{
+			ID: kid,
+		})
+		id, clientDataJSON, authData, signature, _, err := auth.Get(assertOpts)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if !bytes.Equal(id, kid) {
+			t.Errorf("Unexpected key ID. Got %q, want %q", id, kid)
+		}
+		if err := verifySignature(coseKey, authData, clientDataJSON, signature); err != nil {
+			t.Fatalf("verifySignature: %v", err)
+		}
+	}
+
+	auth.RotateKeys()
+	// All signatures below should be invalid.
+	for keyID, coseKey := range keys {
+		assertOpts, err := newAssertionOptions()
+		if err != nil {
+			t.Fatalf("newAssertionOptions: %v", err)
+		}
+		kid, _ := base64.RawURLEncoding.DecodeString(keyID)
+		assertOpts.AllowCredentials = append(assertOpts.AllowCredentials, CredentialID{
+			ID: kid,
+		})
+		id, clientDataJSON, authData, signature, _, err := auth.Get(assertOpts)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if !bytes.Equal(id, kid) {
+			t.Errorf("Unexpected key ID. Got %q, want %q", id, kid)
+		}
+		if err := verifySignature(coseKey, authData, clientDataJSON, signature); err == nil {
+			t.Fatal("verifySignature should have failed")
+		}
+	}
+}

--- a/proxy/internal/saml/saml.go
+++ b/proxy/internal/saml/saml.go
@@ -48,7 +48,7 @@ import (
 // http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf
 
 type CookieManager interface {
-	SetAuthTokenCookie(w http.ResponseWriter, userID, sessionID string, extraClaims map[string]string) error
+	SetAuthTokenCookie(w http.ResponseWriter, userID, sessionID string, extraClaims map[string]any) error
 	ClearCookies(w http.ResponseWriter) error
 }
 
@@ -229,7 +229,7 @@ func (p *Provider) HandleCallback(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	extraClaims := map[string]string{
+	extraClaims := map[string]any{
 		"source": findElementText(v, "./Issuer"),
 	}
 	for _, a := range v.FindElements("./AttributeStatement/Attribute") {

--- a/proxy/logout-template.html
+++ b/proxy/logout-template.html
@@ -5,28 +5,7 @@
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=10, minimum-scale=0.1" />
 <link rel="icon" href="/.sso/favicon.ico" />
-<style>
-html {
-  margin: 0;
-  height: 100%;
-  background-color: black;
-} 
-body {
-  margin: 0;
-  height: 100%;
-  font-family: monospace;
-}
-#message {
-  color: white;
-  text-align: center;
-  position: fixed;
-  left: 50vw;
-  top: 40vh;
-  transform: translate(-50%, -50%);
-  padding: 10px;
-  max-width: 90vw;
-}
-</style>
+<link rel="stylesheet" type="text/css" href="/.sso/style.css" />
 </head>
 <body>
 <div id="message">

--- a/proxy/permission-denied-template.html
+++ b/proxy/permission-denied-template.html
@@ -4,48 +4,10 @@
 <title>Permission denied</title>
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=10, minimum-scale=0.1" />
+<link rel="stylesheet" type="text/css" href="/.sso/style.css" />
 <style>
-html {
-  margin: 0;
-  height: 100%;
-  background-color: black;
-} 
-body {
-  margin: 0;
-  height: 100%;
-  font-family: monospace;
-}
-a {
-  color: white;
-}
-#buttons {
-  position: fixed;
-  top: 10px;
-  right: 10px;
-}
-a.button {
-  text-decoration: none;
-  border: solid 1px black;
-  background-color: lightgray;
-  color: black;
-  margin: 1em;
-  padding: 0.5em;
-}
-a.button:hover {
-  background-color: darkgray;
-}
-#message {
-  color: white;
-  text-align: center;
-  position: fixed;
-  left: 50vw;
-  top: 40vh;
-  transform: translate(-50%, -50%);
-  padding: 10px;
-  max-width: 90vw;
-}
 #target {
-  margin: 2em;
+  line-height: 2em;
 }
 .big {
   font-size: 800%;
@@ -59,7 +21,7 @@ a.button:hover {
 </div>
 <div id="message">
 <div class="big">🛂</div>
-<div>{{.Subject}} is not allowed to access</div>
+<div><em>{{.Subject}}</em> is not permitted to access</div>
 <div id="target"><a href="{{.URL}}">{{.DisplayURL}}</a></div>
 </div>
 </div>

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -482,6 +482,9 @@ func (p *Proxy) Reconfigure(cfg *Config) error {
 				}),
 				ssoBypass: true,
 			}
+			if m, ok := be.SSO.p.(*passkeys.Manager); ok {
+				m.SetACL(be.SSO.ACL)
+			}
 		}
 	}
 	if p.cfg != nil {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -24,6 +24,9 @@
 // Package proxy implements a simple lightweight TLS termination proxy that uses
 // Let's Encrypt to provide TLS encryption for any number of TCP and HTTP
 // servers and server names concurrently on the same port.
+//
+// It can also act as a reverse HTTP proxy with optional user authentication
+// with SAML, OpenID Connect, and/or passkeys.
 package proxy
 
 import (
@@ -54,6 +57,7 @@ import (
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/cookiemanager"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/netw"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/oidc"
+	"github.com/c2FmZQ/tlsproxy/proxy/internal/passkeys"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/saml"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/tokenmanager"
 )
@@ -285,6 +289,38 @@ func (p *Proxy) Reconfigure(cfg *Config) error {
 			cm:               cm,
 		}
 	}
+	for _, pp := range cfg.PasskeyProviders {
+		host, path, err := hostAndPath(pp.Endpoint)
+		if err != nil {
+			return err
+		}
+		other, ok := identityProviders[pp.IdentityProvider]
+		if !ok {
+			return fmt.Errorf("invalid identityProvider %q", pp.IdentityProvider)
+		}
+		issuer := "https://" + host + "/"
+		cm := cookiemanager.New(p.tokenManager, pp.Name, pp.Domain, issuer)
+		cfg := passkeys.Config{
+			Store:              p.store,
+			Other:              other.identityProvider,
+			Endpoint:           pp.Endpoint,
+			EventRecorder:      er,
+			CookieManager:      cm,
+			OtherCookieManager: other.cm,
+			ClaimsFromCtx:      claimsFromCtx,
+		}
+		provider, err := passkeys.NewManager(cfg)
+		if err != nil {
+			return err
+		}
+		identityProviders[pp.Name] = idp{
+			identityProvider: provider,
+			callbackHost:     host,
+			callbackPath:     path,
+			domain:           pp.Domain,
+			cm:               cm,
+		}
+	}
 
 	backends := make(map[string]*Backend, len(cfg.Backends))
 	for _, be := range cfg.Backends {
@@ -307,6 +343,10 @@ func (p *Proxy) Reconfigure(cfg *Config) error {
 				handler:   logHandler(http.HandlerFunc(be.serveSSOStatus)),
 				ssoBypass: true,
 			}
+			be.localHandlers["/.sso/style.css"] = localHandler{
+				handler:   logHandler(http.HandlerFunc(be.serveSSOStyle)),
+				ssoBypass: true,
+			}
 			be.localHandlers["/.sso/logout"] = localHandler{
 				handler:   logHandler(http.HandlerFunc(be.serveLogout)),
 				ssoBypass: true,
@@ -314,6 +354,11 @@ func (p *Proxy) Reconfigure(cfg *Config) error {
 			be.localHandlers["/.sso/favicon.ico"] = localHandler{
 				handler:   http.HandlerFunc(p.faviconHandler),
 				ssoBypass: true,
+			}
+			if m, ok := be.SSO.p.(*passkeys.Manager); ok {
+				be.localHandlers["/.sso/passkeys"] = localHandler{
+					handler: http.HandlerFunc(m.ManageKeys),
+				}
 			}
 
 			if ls := be.SSO.LocalOIDCServer; ls != nil && len(be.ServerNames) > 0 {

--- a/proxy/sso-status-template.html
+++ b/proxy/sso-status-template.html
@@ -5,48 +5,10 @@
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=10, minimum-scale=0.1" />
 <link rel="icon" href="/.sso/favicon.ico" />
+<link rel="stylesheet" type="text/css" href="/.sso/style.css" />
 <style>
-html {
-  margin: 0;
-  height: 100%;
-  background-color: black;
-} 
-body {
-  margin: 0;
-  height: 100%;
-  font-family: monospace;
-}
-#buttons {
-  position: fixed;
-  top: 10px;
-  right: 10px;
-}
-a.button {
-  text-decoration: none;
-  border: solid 1px black;
-  background-color: lightgray;
-  color: black;
-  margin: 1em;
-  padding: 0.5em;
-}
-a.button:hover {
-  background-color: darkgray;
-}
-#message {
-  color: white;
-  text-align: left;
-  position: fixed;
-  left: 50vw;
-  top: 50vh;
-  transform: translate(-50%, -50%);
-  border: solid 1px gray;
-  padding: 1em;
-  width: clamp(20em, 40em, 90vw);
-  max-height: 80vh;
-  overflow: scroll;
-  background-color: black;
-}
 #claims {
+  text-align: left;
   display: grid;
   grid-template-columns: 1fr 2fr;
   gap: 0;
@@ -64,21 +26,24 @@ a.button:hover {
 </head>
 <body>
 <div id="buttons">
+{{ if len .Claims | ne 0 }}
 <a class="button" href="/.sso/logout?u={{.Token}}">Switch Account</a>
 <a class="button" href="/.sso/logout">Logout</a>
+{{ else }}
+<a class="button" href="/.sso/logout?u={{.Token}}">Login</a>
+{{ end }}
 </div>
 <div id="message">
 {{ if len .Claims | ne 0 }}
-User Identity:
+Your Identity
 <div id="claims">
 {{ range .Claims }}
 <div>{{.Key}}</div>
 <div>{{.Value}}{{ if eq .Key "picture" }}<br /><img style="max-width: 40vw; max-height: 40vh;" src="{{.Value}}" />{{ end }}</div>
 {{ end }}
 {{ else }}
-User Is Not Logged In
+Your Are Not Logged In
 {{ end }}
-</div>
 </div>
 </div>
 </body>

--- a/proxy/sso_test.go
+++ b/proxy/sso_test.go
@@ -24,8 +24,11 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
 	"io"
 	"log"
 	"net"
@@ -33,6 +36,7 @@ import (
 	"net/http/cookiejar"
 	"net/http/httptest"
 	"net/url"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -42,10 +46,11 @@ import (
 
 	"github.com/c2FmZQ/tlsproxy/certmanager"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/oidc"
+	"github.com/c2FmZQ/tlsproxy/proxy/internal/passkeys"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/tokenmanager"
 )
 
-func TestSSOEnforce(t *testing.T) {
+func TestSSOEnforceOIDC(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -186,6 +191,269 @@ func TestSSOEnforce(t *testing.T) {
 	}
 	if got, want := len(cookies), 0; got != want {
 		t.Errorf("len(cookies) = %v, want %v", got, want)
+	}
+}
+
+func TestSSOEnforcePasskey(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	idp := newIDPServer(t)
+	defer idp.Close()
+
+	ca, err := certmanager.New("root-ca.example.com", t.Logf)
+	if err != nil {
+		t.Fatalf("certmanager.New: %v", err)
+	}
+	be := newHTTPServer(t, ctx, "https-server", ca)
+
+	proxy := newTestProxy(
+		&Config{
+			HTTPAddr: "localhost:0",
+			TLSAddr:  "localhost:0",
+			CacheDir: t.TempDir(),
+			MaxOpen:  100,
+			OIDCProviders: []*ConfigOIDC{
+				{
+					Name:          "test-idp",
+					AuthEndpoint:  idp.URL + "/authorization",
+					TokenEndpoint: idp.URL + "/token",
+					RedirectURL:   "https://oauth2.example.com/redirect",
+					ClientID:      "CLIENTID",
+					ClientSecret:  "CLIENTSECRET",
+					Domain:        "example.com",
+				},
+			},
+			PasskeyProviders: []*ConfigPasskey{
+				{
+					Name:             "test-passkey",
+					IdentityProvider: "test-idp",
+					Endpoint:         "https://login.example.com/passkey",
+					Domain:           "example.com",
+				},
+			},
+			Backends: []*Backend{
+				{
+					ServerNames: []string{
+						"https.example.com",
+					},
+					Mode: "HTTPS",
+					Addresses: []string{
+						be.String(),
+					},
+					ForwardServerName: "https-server",
+					ForwardRateLimit:  1000,
+					ForwardRootCAs:    ca.RootCAPEM(),
+					SSO: &BackendSSO{
+						Provider: "test-passkey",
+					},
+				},
+				{
+					ServerNames: []string{
+						"oauth2.example.com",
+						"login.example.com",
+					},
+					Mode:             "HTTPS",
+					ForwardRateLimit: 1000,
+					SSO: &BackendSSO{
+						Provider: "test-idp",
+					},
+				},
+			},
+		},
+		ca,
+	)
+	if err := proxy.Start(ctx); err != nil {
+		t.Fatalf("proxy.Start: %v", err)
+	}
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar: %v", err)
+	}
+
+	get := func(urlToGet string, hdr http.Header, postBody []byte) (int, string, string) {
+		u, err := url.Parse(urlToGet)
+		if err != nil {
+			t.Fatalf("%q: %v", urlToGet, err)
+		}
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = &tls.Config{
+			RootCAs: ca.RootCACertPool(),
+		}
+		var host string
+		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host = addr
+			var d net.Dialer
+			if strings.Contains(addr, "example.com") {
+				return d.DialContext(ctx, "tcp", proxy.listener.Addr().String())
+			}
+			return d.DialContext(ctx, network, addr)
+		}
+		client := http.Client{
+			Transport: transport,
+			Jar:       jar,
+		}
+		req := &http.Request{
+			Method: "GET",
+			URL:    u,
+			Host:   u.Host,
+		}
+		if postBody != nil {
+			req.Method = "POST"
+			req.Body = io.NopCloser(bytes.NewReader(postBody))
+		}
+		if hdr == nil {
+			hdr = make(http.Header)
+		}
+		req.Header = hdr
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("%s: get failed: %v", urlToGet, err)
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("%s: body read: %v", urlToGet, err)
+		}
+		if err := resp.Body.Close(); err != nil {
+			t.Fatalf("%s: body close: %v", urlToGet, err)
+		}
+		return resp.StatusCode, string(body), host
+	}
+
+	// Redirects to login page.
+	code, body, host := get("https://https.example.com/blah", nil, nil)
+	if got, want := code, 200; got != want {
+		t.Errorf("Code = %v, want %v", got, want)
+	}
+	m := regexp.MustCompile(`href="(/passkey[?]get=RegisterNewID&nonce=[^"]*)"`).FindStringSubmatch(body)
+	if len(m) != 2 {
+		t.Fatalf("FindStringSubmatch: %v", m)
+	}
+
+	// Go to register new key page.
+	code, body, _ = get("https://"+host+m[1], nil, nil)
+	if got, want := code, 200; got != want {
+		t.Errorf("Code = %v, want %v", got, want)
+	}
+	if haystack, needle := body, "registerPasskey(&#34;https://https.example.com/blah&#34;);"; !strings.Contains(haystack, needle) {
+		t.Errorf("Body = %v, want %v", haystack, needle)
+	}
+
+	auth, err := passkeys.NewFakeAuthenticator()
+	if err != nil {
+		t.Fatalf("passkeys.NewFakeAuthenticator: %v", err)
+	}
+	auth.SetOrigin("https://" + host)
+
+	// Get the attestation options.
+	code, body, _ = get("https://"+host+"/passkey?get=AttestationOptions", nil, nil)
+	if got, want := code, 200; got != want {
+		t.Errorf("Code = %v, want %v", got, want)
+	}
+	var ao passkeys.AttestationOptions
+	if err := json.Unmarshal([]byte(body), &ao); err != nil {
+		t.Fatalf("AttestationOptions: %v", err)
+	}
+	clientDataJSON, attestationObject, err := auth.Create(&ao)
+	if err != nil {
+		t.Fatalf("auth.Create: %v", err)
+	}
+	data := struct {
+		ClientDataJSON    passkeys.Bytes `json:"clientDataJSON"`
+		AttestationObject passkeys.Bytes `json:"attestationObject"`
+		Transports        []string       `json:"transports"`
+	}{
+		ClientDataJSON:    clientDataJSON,
+		AttestationObject: attestationObject,
+		Transports:        []string{"usb"},
+	}
+	dataJSON, _ := json.Marshal(data)
+
+	hdr := http.Header{}
+	hdr.Set("content-type", "application/x-www-form-urlencoded")
+	postBody := "args=" + url.QueryEscape(string(dataJSON))
+
+	// Send the new passkey attestation.
+	code, body, _ = get("https://"+host+"/passkey?get=AddKey", hdr, []byte(postBody))
+	if got, want := code, 200; got != want {
+		t.Errorf("Code = %v, want %v", got, want)
+	}
+	if got, want := body, "{\"result\":\"ok\"}\n"; got != want {
+		t.Errorf("Body = %v, want %v", got, want)
+	}
+
+	// We should be logged in now.
+	code, body, host = get("https://https.example.com/blah", nil, nil)
+	if got, want := code, 200; got != want {
+		t.Errorf("Code = %v, want %v", got, want)
+	}
+	if got, want := body, "[https-server] /blah\n"; got != want {
+		t.Errorf("Body = %v, want %v", got, want)
+	}
+
+	// Logout
+	code, body, _ = get("https://"+host+"/.sso/logout", nil, nil)
+	if got, want := code, 200; got != want {
+		t.Errorf("Code = %v, want %v", got, want)
+	}
+
+	// Redirects to login page.
+	code, body, host = get("https://https.example.com/blah", nil, nil)
+	if got, want := code, 200; got != want {
+		t.Errorf("Code = %v, want %v", got, want)
+	}
+	if haystack, needle := body, "loginWithPasskey(&#34;https://https.example.com/blah&#34;);"; !strings.Contains(haystack, needle) {
+		t.Errorf("Body = %v, want %v", haystack, needle)
+	}
+
+	// Get the assertion options.
+	code, body, _ = get("https://"+host+"/passkey?get=AssertionOptions", nil, nil)
+	if got, want := code, 200; got != want {
+		t.Errorf("Code = %v, want %v", got, want)
+	}
+	var aso passkeys.AssertionOptions
+	if err := json.Unmarshal([]byte(body), &aso); err != nil {
+		t.Fatalf("AssertionOptions: %v", err)
+	}
+	id, clientDataJSON, authData, signature, userHandle, err := auth.Get(&aso)
+	if err != nil {
+		t.Fatalf("auth.Get: %v", err)
+	}
+	data2 := struct {
+		ID                string         `json:"id"`
+		ClientDataJSON    passkeys.Bytes `json:"clientDataJSON"`
+		AuthenticatorData passkeys.Bytes `json:"authenticatorData"`
+		Signature         passkeys.Bytes `json:"signature"`
+		UserHandle        passkeys.Bytes `json:"userHandle"`
+	}{
+		ID:                base64.RawURLEncoding.EncodeToString(id),
+		ClientDataJSON:    clientDataJSON,
+		AuthenticatorData: authData,
+		Signature:         signature,
+		UserHandle:        userHandle,
+	}
+	dataJSON, _ = json.Marshal(data2)
+
+	hdr = http.Header{}
+	hdr.Set("content-type", "application/x-www-form-urlencoded")
+	postBody = "args=" + url.QueryEscape(string(dataJSON))
+
+	// Send the passkey assertion.
+	code, body, _ = get("https://"+host+"/passkey?get=Check", hdr, []byte(postBody))
+	if got, want := code, 200; got != want {
+		t.Errorf("Code = %v, want %v", got, want)
+	}
+	if got, want := body, "{\"result\":\"ok\"}\n"; got != want {
+		t.Errorf("Body = %v, want %v", got, want)
+	}
+
+	// We should be logged in again.
+	code, body, host = get("https://https.example.com/blah", nil, nil)
+	if got, want := code, 200; got != want {
+		t.Errorf("Code = %v, want %v", got, want)
+	}
+	if got, want := body, "[https-server] /blah\n"; got != want {
+		t.Errorf("Body = %v, want %v", got, want)
 	}
 }
 

--- a/proxy/sso_test.go
+++ b/proxy/sso_test.go
@@ -485,7 +485,7 @@ func newIDPServer(t *testing.T) *idpServer {
 	opts := oidc.ServerOptions{
 		TokenManager: tm,
 		Issuer:       "https://idp.example.com",
-		ClaimsFromCtx: func(context.Context) jwt.Claims {
+		ClaimsFromCtx: func(context.Context) jwt.MapClaims {
 			return jwt.MapClaims{
 				"sub": "bob@example.com",
 			}

--- a/proxy/style.css
+++ b/proxy/style.css
@@ -1,0 +1,47 @@
+html {
+  margin: 0;
+  height: 100%;
+  background-color: black;
+  color: white;
+}
+body {
+  margin: 0;
+  height: 100%;
+  font-family: monospace;
+}
+#buttons {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+}
+a {
+  color: white;
+  cursor: pointer;
+}
+a.button {
+  text-decoration: none;
+  border: solid 1px black;
+  border-radius: 1em;
+  background-color: lightgray;
+  color: black;
+  margin: 1em;
+  padding: 0.5em;
+  line-height: 3em;
+  white-space: nowrap;
+}
+a.button:hover {
+  background-color: darkgray;
+}
+#message {
+  color: white;
+  text-align: center;
+  position: fixed;
+  left: 50vw;
+  top: 50vh;
+  transform: translate(-50%, -50%);
+  padding: 1em;
+  background-color: black;
+  width: clamp(20em, 40em, 90vw);
+  max-height: 80vh;
+  overflow: scroll;
+}


### PR DESCRIPTION
### Description

Passkeys (https://fidoalliance.org/passkeys/) can now be used for SSO authentication. The set up process requires verifying the user's identity with another identity provider first. After the user's identity has been verified, a passkey is registered and will be used for authentication going forward.

This change imports a lot of code from c2FmZQ-server and re-licenses it under the terms of the MIT license.

### Type of change

* [x] New feature
* [ ] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)

### How is this change tested ?

* [x] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
