### PR TITLE
Add built-in PKI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,6 +13,8 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: '>=1.21.3'
+    - name: Generate files
+      run: go generate ./...
     - name: Build
       run: go build ./...
     - name: Run go vet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: '>=1.21.3'
+    - name: Generate files
+      run: go generate ./...
     - name: Build
       run: go build ./...
     - name: Run go vet

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apk add ca-certificates
 ADD . /app/go/src/tlsproxy
 WORKDIR /app/go/src/tlsproxy
 RUN go mod download
+RUN go generate ./...
 RUN source version.sh && go install -ldflags="-s -w -X main.Version=${VERSION:-dev}" .
 
 FROM scratch

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ backends:
       .....
       -----END CERTIFICATE-----
     acl:
-    - CN=admin-user
+    - SUBJECT:CN=admin-user
   addresses:
   - 192.168.4.100:443
   forwardServerName: restricted-internal.example.com

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Overview of features:
 * [x] Terminate _TCP_ connections, and forward the TLS connection to any TLS server (passthrough). The proxy doesn't see the plaintext.
 * [x] Terminate HTTPS connections, and forward the requests to HTTP or HTTPS servers (http/1 only, not recommended with c2fmzq-server).
 * [x] TLS client authentication & authorization (when the proxy terminates the TLS connections).
+* [x] Built-in Certificate Authority for managing client and backend server TLS certificates.
 * [x] User authentication with OpenID Connect, SAML, and/or passkeys (for HTTP and HTTPS connections). Optionally issue JSON Web Tokens (JWT) to authenticated users to use with the backend services and/or run a local OpenID Connect server for backend services.
 * [x] Access control by IP address.
 * [x] Routing based on Server Name Indication (SNI), with optional default route when SNI isn't used.
@@ -117,7 +118,8 @@ backends:
   - restricted.example.com
   mode: https
   clientAuth:
-    rootCAs: |
+    rootCAs:
+    - |
       -----BEGIN CERTIFICATE-----
       .....
       -----END CERTIFICATE-----

--- a/build-release-binaries.sh
+++ b/build-release-binaries.sh
@@ -2,6 +2,8 @@
 
 mkdir -p bin
 
+go generate ./...
+
 export CGO_ENABLED=0
 export GOARM=7
 flag="-ldflags=-extldflags=-static -s -w -X main.Version=${GITHUB_REF_NAME:-dev}"

--- a/examples/example-config.yaml
+++ b/examples/example-config.yaml
@@ -50,17 +50,20 @@ backends:
 - serverNames:
   - secure.example.com
   clientAuth:
-    rootCAs: *myCA
+    rootCAs:
+    - *myCA
   mode: tls
   addresses:
   - 192.168.2.200:443
   forwardServerName: secure-internal.example.com
-  forwardRootCAs: *myCA
+  forwardRootCAs:
+  - *myCA
 
 - serverNames:
   - ssh.example.com
   clientAuth:
-    rootCAs: *myCA
+    rootCAs:
+    - *myCA
   addresses:
   - 192.168.8.20:22
 

--- a/examples/pki/README.md
+++ b/examples/pki/README.md
@@ -1,0 +1,56 @@
+# PKI, built-in Certificate Authority
+
+TLSPROXY has built-in support for managing X.509 Certificates.
+
+```yaml
+pki:
+- name: "EXAMPLE CA"
+  # Optional: Publish the CA's certificate.
+  issuingCertificateUrls:
+  - https://pki.example.com/ca
+  - https://pki.example.com/ca.pem
+  # Optional: Publish the CA's Revocation List.
+  crlDistributionPoints:
+  - https://pki.example.com/crl
+  - https://pki.example.com/crl.pem
+  # Optional: Enable OCSP (Online Certificate Status Protocol).
+  ocspServers:
+  - https://pki.example.com/ocsp
+  # Users can manage their own certificates with this endpoint.
+  endpoint: https://pki-internal.example.com/certs
+  # Optional: Admins can revoke anybody's certificates.
+  admins:
+  - bob@example.com
+
+backends:
+# Optional: Use a server name to publich the CA's certificate and Revocation
+# List.
+- serverNames:
+  - pki.example.com
+  mode: local
+
+# This server name is used to manage certificates. 
+- serverNames:
+  - pki-internal.example.com
+  mode: local
+  allowIPs:
+  - 192.168.0.0/24
+  sso:
+    provider: sso-provider # definition omitted for this example
+    forceReAuth: 1h
+    # The ACL controls who has access to issue and revoke certificates for
+    # themselves.
+    acl:
+    - alice@example.com
+    - bob@example.com
+
+# Then use EXAMPLE CA to authenticate and authorize TLS clients.
+- serverNames:
+  - secure.example.com
+  clientAuth:
+  - rootCAs:
+    - "EXAMPLE CA"
+    acl:
+    - EMAIL:alice@example.com
+    - EMAIL:bob@example.com
+```

--- a/examples/pki/README.md
+++ b/examples/pki/README.md
@@ -5,13 +5,11 @@ TLSPROXY has built-in support for managing X.509 Certificates.
 ```yaml
 pki:
 - name: "EXAMPLE CA"
-  # Optional: Publish the CA's certificate.
+  # Optional: Publish the CA's certificate(s).
   issuingCertificateUrls:
-  - https://pki.example.com/ca
   - https://pki.example.com/ca.pem
   # Optional: Publish the CA's Revocation List.
   crlDistributionPoints:
-  - https://pki.example.com/crl
   - https://pki.example.com/crl.pem
   # Optional: Enable OCSP (Online Certificate Status Protocol).
   ocspServers:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/beevik/etree v1.2.0
-	github.com/c2FmZQ/storage v0.1.0
+	github.com/c2FmZQ/storage v0.1.1
 	github.com/fxamacker/cbor/v2 v2.5.0
 	github.com/go-test/deep v1.1.0
 	github.com/golang-jwt/jwt/v5 v5.0.0
@@ -13,6 +13,7 @@ require (
 	golang.org/x/sys v0.13.0
 	golang.org/x/time v0.3.0
 	gopkg.in/yaml.v3 v3.0.1
+	software.sslmate.com/src/go-pkcs12 v0.3.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
 github.com/beevik/etree v1.2.0 h1:l7WETslUG/T+xOPs47dtd6jov2Ii/8/OjCldk5fYfQw=
 github.com/beevik/etree v1.2.0/go.mod h1:aiPf89g/1k3AShMVAzriilpcE4R/Vuor90y83zVZWFc=
-github.com/c2FmZQ/storage v0.1.0 h1:ZhAV43sS5bWNfeEZZElnNUDyg56wJh3u2J9UFNRDbI4=
-github.com/c2FmZQ/storage v0.1.0/go.mod h1:rKT3TTRmsAFp5IcI3hV3KNCQYqfDy9oOJ7uZxkyjSS8=
+github.com/c2FmZQ/storage v0.1.1 h1:gYXqsX2Kloarl4UZnF0P2H1EN5mNfJObtdogDtznDnQ=
+github.com/c2FmZQ/storage v0.1.1/go.mod h1:Nc3Sw1ghQRXrWNPGU81XdhHmcrmF9Pk2a4YDE/7sZrQ=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -38,16 +38,10 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
-golang.org/x/crypto v0.13.0 h1:mvySKfSWJ+UKUii46M40LOvyWfN0s2U+46/jDd0e6Ck=
-golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=
 golang.org/x/crypto v0.14.0 h1:wBqGXzWJW6m1XrIKlAH0Hs1JJ7+9KBwnIO8v66Q9cHc=
 golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
-golang.org/x/net v0.15.0 h1:ugBLEUaxABaB5AJqW9enI0ACdci2RUd4eP51NTBvuJ8=
-golang.org/x/net v0.15.0/go.mod h1:idbUs1IY1+zTqbi8yxTbhexhEEk5ur9LInksu6HrEpk=
 golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
 golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
-golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
-golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
@@ -63,3 +57,7 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+software.sslmate.com/src/go-pkcs12 v0.2.1 h1:tbT1jjaeFOF230tzOIRJ6U5S1jNqpsSyNjzDd58H3J8=
+software.sslmate.com/src/go-pkcs12 v0.2.1/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
+software.sslmate.com/src/go-pkcs12 v0.3.0 h1:ZYaL72OA2n9UgvesM62z1xmb4PYjgzswQ7xkuC08FEI=
+software.sslmate.com/src/go-pkcs12 v0.3.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=

--- a/proxy/backend.go
+++ b/proxy/backend.go
@@ -149,7 +149,7 @@ func (be *Backend) authorize(cert *x509.Certificate) error {
 	if be.ClientAuth == nil || be.ClientAuth.ACL == nil {
 		return nil
 	}
-	if subject := cert.Subject.String(); subject != "" && slices.Contains(*be.ClientAuth.ACL, subject) {
+	if subject := cert.Subject.String(); subject != "" && (slices.Contains(*be.ClientAuth.ACL, subject) || slices.Contains(*be.ClientAuth.ACL, "SUBJECT:"+subject)) {
 		return nil
 	}
 	for _, v := range cert.DNSNames {

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -282,7 +282,7 @@ type ClientAuth struct {
 	// this service. A nil value disabled the authorization check and allows
 	// any valid client certificate. Otherwise, the value is a slice of
 	// Subject or Subject Alternate Name strings from the client X509
-	// certificate, e.g. CN=Bob or EMAIL:bob@example.com
+	// certificate, e.g. SUBJECT:CN=Bob or EMAIL:bob@example.com
 	ACL *[]string `yaml:"acl,omitempty"`
 	// RootCAs a list of:
 	// - CA names defined in the PKI section,

--- a/proxy/config_test.go
+++ b/proxy/config_test.go
@@ -101,10 +101,10 @@ func TestReadConfig(t *testing.T) {
 				ForwardRateLimit: 5,
 				Mode:             "TLS",
 				ClientAuth: &ClientAuth{
-					RootCAs: demoCert,
+					RootCAs: []string{demoCert},
 				},
 				ForwardServerName: "secure-internal.example.com",
-				ForwardRootCAs:    demoCert,
+				ForwardRootCAs:    []string{demoCert},
 				ForwardTimeout:    30 * time.Second,
 			},
 			{
@@ -117,7 +117,7 @@ func TestReadConfig(t *testing.T) {
 				ForwardRateLimit: 5,
 				Mode:             "TCP",
 				ClientAuth: &ClientAuth{
-					RootCAs: demoCert,
+					RootCAs: []string{demoCert},
 				},
 				ForwardTimeout: 30 * time.Second,
 			},

--- a/proxy/http.go
+++ b/proxy/http.go
@@ -100,9 +100,17 @@ func (l *proxyListener) Addr() net.Addr {
 	return l.addr
 }
 
+func userAgent(req *http.Request) string {
+	ua := req.Header.Get("user-agent")
+	if len(ua) > 200 {
+		ua = ua[:197] + "..."
+	}
+	return ua
+}
+
 func logHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		log.Printf("REQ %s ➔ %s %s", formatReqDesc(req), req.Method, req.URL)
+		log.Printf("REQ %s ➔ %s %s (%q)", formatReqDesc(req), req.Method, req.URL, userAgent(req))
 		next.ServeHTTP(w, req)
 	})
 }

--- a/proxy/internal/cookiemanager/cookiemanager_test.go
+++ b/proxy/internal/cookiemanager/cookiemanager_test.go
@@ -50,7 +50,7 @@ func TestCookies(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 
-	if err := cm.SetAuthTokenCookie(recorder, "test@example.com", "session123", nil); err != nil {
+	if err := cm.SetAuthTokenCookie(recorder, "test@example.com", "session123", "example.com", nil); err != nil {
 		t.Fatalf("SetAuthTokenCookie: %v", err)
 	}
 

--- a/proxy/internal/passkeys/auth-template.html
+++ b/proxy/internal/passkeys/auth-template.html
@@ -13,6 +13,9 @@
   width: 100vw;
   text-align: center;
 }
+.big {
+  font-size: 300%;
+}
 </style>
 </head>
 <body>
@@ -27,16 +30,16 @@
   </div>
   <div id="message">
 {{- if eq .Mode "Login" }}
-    <div><a class="button" onclick="loginWithPasskey({{.RedirectURL}});">Login</a></div>
+    <div><a class="button big" onclick="loginWithPasskey({{.RedirectURL}},{{.Nonce}});">Login</a></div>
 {{- end }}
 {{- if eq .Mode "RegisterNewID" }}
     <div>{{.Subject}}</div>
   {{- if .IsAllowed }}
     {{- if .IsRegistered }}
     <div>Already Registered</div>
-    <div><a class="button" onclick="loginWithPasskey({{.RedirectURL}});">Login</a></div>
+    <div><a class="button" onclick="loginWithPasskey({{.RedirectURL}},{{.Nonce}});">Login</a></div>
     {{- else }}
-    <div><a class="button" onclick="registerPasskey({{.RedirectURL}});">Register This Identity</a></div>
+    <div><a class="button" onclick="registerPasskey({{.RedirectURL}},{{.Nonce}});">Register This Identity</a></div>
     {{- end }}
   {{- else }}
     <div>Is Not Allowed</div>

--- a/proxy/internal/passkeys/manager.go
+++ b/proxy/internal/passkeys/manager.go
@@ -422,7 +422,7 @@ func serveWebauthnJS(w http.ResponseWriter, req *http.Request) {
 	sum := sha256.Sum256(webauthnJSEmbed)
 	etag := `"` + hex.EncodeToString(sum[:]) + `"`
 
-	w.Header().Set("Content-Type", "text/css")
+	w.Header().Set("Content-Type", "text/javascript")
 	w.Header().Set("Cache-Control", "public")
 	w.Header().Set("Etag", etag)
 

--- a/proxy/internal/passkeys/webauthn.go
+++ b/proxy/internal/passkeys/webauthn.go
@@ -256,7 +256,8 @@ func parseAuthenticatorData(raw []byte, ad *authenticatorData) error {
 		raw = raw[int(sz):]
 
 		var coseKey cbor.RawMessage
-		if err := cbor.Unmarshal(raw, &coseKey); err != nil {
+		var err error
+		if raw, err = cbor.UnmarshalFirst(raw, &coseKey); err != nil {
 			return err
 		}
 		ad.AttestedCredentials.COSEKey = Bytes(coseKey)

--- a/proxy/internal/passkeys/webauthn.js
+++ b/proxy/internal/passkeys/webauthn.js
@@ -23,14 +23,17 @@
  * SOFTWARE.
  */
 
-const self = window.location.pathname;
-
-function registerPasskey(redirectUrl) {
+function registerPasskey(redirectUrl, nonce) {
   if (!('PublicKeyCredential' in window)) {
     throw new Error('Browser doesn\'t support WebAuthn');
   }
 
-  fetch(self+'?get=AttestationOptions')
+  fetch('?get=AttestationOptions', {
+    method: 'POST',
+    headers: {
+      'x-csrf-check': 1,
+    },
+  })
   .then(resp => {
     if (resp.status !== 200) {
       throw resp.status;
@@ -56,10 +59,11 @@ function registerPasskey(redirectUrl) {
       attestationObject: Array.from(new Uint8Array(pkc.response.attestationObject)),
       transports: pkc.response.getTransports(),
     });
-    return fetch(self+'?get=AddKey', {
+    return fetch('?get=AddKey'+(nonce?'&nonce='+nonce:''), {
       method: 'POST',
       headers: {
         'content-type': 'application/x-www-form-urlencoded',
+        'x-csrf-check': 1,
       },
       body: 'args=' + encodeURIComponent(v),
     });
@@ -86,11 +90,16 @@ function registerPasskey(redirectUrl) {
   });
 }
 
-function loginWithPasskey(redirectUrl) {
+function loginWithPasskey(redirectUrl, nonce) {
   if (!('PublicKeyCredential' in window)) {
     throw new Error('Browser doesn\'t support WebAuthn');
   }
-  fetch(self+'?get=AssertionOptions')
+  fetch('?get=AssertionOptions', {
+    method: 'POST',
+    headers: {
+      'x-csrf-check': 1,
+    },
+  })
   .then(resp => {
     if (resp.status !== 200) {
       throw resp.status;
@@ -112,10 +121,11 @@ function loginWithPasskey(redirectUrl) {
         signature: Array.from(new Uint8Array(pkc.response.signature)),
         userHandle: Array.from(new Uint8Array(pkc.response.userHandle)),
     });
-    return fetch(self+'?get=Check', {
+    return fetch('?get=Check&nonce='+nonce, {
       method: 'POST',
       headers: {
         'content-type': 'application/x-www-form-urlencoded',
+        'x-csrf-check': 1,
       },
       credentials: 'same-origin',
       body: 'args=' + encodeURIComponent(v),
@@ -147,10 +157,11 @@ function deleteKey(id) {
   if (!window.confirm('Delete key ID ' + id + '?')) {
     return;
   }
-  fetch(self+'?get=DeleteKey', {
+  fetch('?get=DeleteKey', {
     method: 'POST',
     headers: {
       'content-type': 'application/x-www-form-urlencoded',
+      'x-csrf-check': 1,
     },
       body: 'id=' + encodeURIComponent(id),
   })
@@ -174,8 +185,11 @@ function deleteKey(id) {
 
 
 function switchAccount(redirectUrl) {
-  fetch(self+'?get=Switch', {
+  fetch('?get=Switch', {
     method: 'POST',
+    headers: {
+      'x-csrf-check': 1,
+    },
   })
   .then(resp => {
     if (resp.status !== 200) {

--- a/proxy/internal/pki/.gitignore
+++ b/proxy/internal/pki/.gitignore
@@ -1,0 +1,3 @@
+pki.wasm
+pki.wasm.bz2
+wasm_exec.js

--- a/proxy/internal/pki/build-wasm.sh
+++ b/proxy/internal/pki/build-wasm.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -e
+
+cd $(dirname $0)
+
+(cd clientwasm && GOOS=js GOARCH=wasm go build -ldflags="-extldflags=-s -w" -o ../pki.wasm .)
+
+cp $(go env GOROOT)/misc/wasm/wasm_exec.js .
+bzip2 -c9 < pki.wasm > pki.wasm.bz2
+ls -l pki.wasm.bz2 wasm_exec.js

--- a/proxy/internal/pki/certs.html
+++ b/proxy/internal/pki/certs.html
@@ -100,6 +100,7 @@ key is never sent to the server.
 <option value="rsa-3072">RSA 3072</option>
 <option value="rsa-4096">RSA 4096</option>
 </select></div>
+<div><b>Label:</b></div><div><input type="text" name="label" size="20" placeholder="optional common name suffix" /></div>
 <div><b>DNS Name:</b></div><div><input type="text" name="dnsname" size="20" placeholder="optional (server certs)" /></div>
 <div><b>Password:</b></div><div><input type="password" name="pw1" size="20" placeholder="required" /></div>
 <div><b>Re-type Password:</b></div><div><input type="password" name="pw2" size="20" placeholder="required" /></div>

--- a/proxy/internal/pki/certs.html
+++ b/proxy/internal/pki/certs.html
@@ -17,7 +17,7 @@
 <div class="certs">Certificate Authority:
 <div class="onecert">
 <div>Subject:</div><div>{{ .CASubject }}</div>
-<div>Serial Number:</div><div>{{ .CASN }}</div>
+<div>SerialNumber:</div><div>{{ .CASN }}</div>
 <div>SubjectKeyId:</div><div>{{ .CASubjectKeyId }}</div>
 </div>
 </div>
@@ -41,7 +41,8 @@
 <div class="onerow{{ if .UsedNow }} usednow{{ end }}">
 <div class="status">{{.Status}}</div>
 <div class="onecert">
-<div>Serial Number:</div><div>{{.SN}}</div>
+<div>SerialNumber:</div><div>{{.SN}}</div>
+<div>PublicKey:</div><div>{{.PublicKey}}</div>
 {{- if eq .Status "Revoked" }}
 <div>Revocation:</div><div>{{.RevocationTime}}</div>
 {{- end }}
@@ -60,8 +61,8 @@
 {{- if .IsCA }}
 <div>IsCA:</div><div>{{.IsCA}}</div>
 {{- end }}
-<div>Not Before:</div><div>{{.NotBefore}}</div>
-<div>Not After:</div><div>{{.NotAfter}}</div>
+<div>NotBefore:</div><div>{{.NotBefore}}</div>
+<div>NotAfter:</div><div>{{.NotAfter}}</div>
 </div>
 <div class="certButtons">
 <a class="button" onclick="showView({{.SN}});">View</a>

--- a/proxy/internal/pki/certs.html
+++ b/proxy/internal/pki/certs.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>PKI</title>
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=10, minimum-scale=0.1" />
+<link rel="stylesheet" type="text/css" href="/.sso/style.css" />
+<link rel="stylesheet" type="text/css" href="?get=static&file=style.css" />
+<script src="?get=static&file=certs.js"></script>
+</head>
+<body>
+<div id="buttons">
+  <a class="button" onclick="showForm();">New Cert</a>
+</div>
+<div id="identity">{{$.Subject}}</div>
+
+<div class="certs">Certificate Authority:
+<div class="onecert">
+<div>Subject:</div><div>{{ .CASubject }}</div>
+<div>Serial Number:</div><div>{{ .CASN }}</div>
+<div>SubjectKeyId:</div><div>{{ .CASubjectKeyId }}</div>
+</div>
+</div>
+
+<form id="filters">
+<b>Filters:</b> <select name="owner" onchange="this.form.submit();">
+<option value="me"{{if eq .Owner "me"}} selected{{end}}>Mine</option>
+<option value="all"{{if eq .Owner "all"}} selected{{end}}>All</option>
+</select>
+<select name="status" onchange="this.form.submit();">
+<option value="valid"{{if eq .Status "valid"}} selected{{end}}>Valid</option>
+<option value="expired"{{if eq .Status "expired"}} selected{{end}}>Expired</option>
+<option value="revoked"{{if eq .Status "revoked"}} selected{{end}}>Revoked</option>
+<option value="all"{{if eq .Status "all"}} selected{{end}}>All</option>
+</select>
+</form>
+
+{{- if len .Certs | ne 0 }}
+<div class="certs">Issued Certificates:
+{{- range .Certs }}
+<div class="onerow{{ if .UsedNow }} usednow{{ end }}">
+<div class="status">{{.Status}}</div>
+<div class="onecert">
+<div>Serial Number:</div><div>{{.SN}}</div>
+{{- if eq .Status "Revoked" }}
+<div>Revocation:</div><div>{{.RevocationTime}}</div>
+{{- end }}
+{{- if ne .Subject "" }}
+<div>Subject:</div><div>{{.Subject}}</div>
+{{- end }}
+{{- range .EmailAddresses }}
+<div>Email:</div><div>{{.}}</div>
+{{- end }}
+{{- range .DNSNames }}
+<div>DNS Name:</div><div>{{.}}</div>
+{{- end }}
+{{- if ne .ExtKeyUsage "" }}
+<div>ExtKeyUsage:</div><div>{{.ExtKeyUsage}}</div>
+{{- end }}
+{{- if .IsCA }}
+<div>IsCA:</div><div>{{.IsCA}}</div>
+{{- end }}
+<div>Not Before:</div><div>{{.NotBefore}}</div>
+<div>Not After:</div><div>{{.NotAfter}}</div>
+</div>
+<div class="certButtons">
+<a class="button" onclick="showView({{.SN}});">View</a>
+<a class="button" onclick="downloadCert({{.SN}});">Download</a>
+{{- if eq .Status "Valid" }}
+{{- if .CanRevoke }}
+<a class="button" onclick="revokeCert({{.SN}});">Revoke</a>
+{{- end }}
+{{- end }}
+</div>
+</div>
+{{- end }}
+</div>
+{{- end }}
+
+<div id="csrform" style="display: none;">
+<h1>New Certificate</h1>
+<h2>Option 1</h2>
+<div>
+Generate a private key in the browser and request a new certificate. The private
+key is never sent to the server.
+</div>
+<form onsubmit="return false;">
+<div class="table2">
+<div><b>Format:</b></div><div><select name="format">
+<option value="gpg">PEM + OpenPGP</option>
+<option value="p12">PKCS#12</option>
+</select></div>
+<div><b>Key Type:</b></div><div><select name="keytype">
+<option value="ecdsa-p224">ECDSA P-224</option>
+<option value="ecdsa-p256" selected>ECDSA P-256</option>
+<option value="ecdsa-p384">ECDSA P-384</option>
+<option value="ecdsa-p521">ECDSA P-521</option>
+<option value="ed25519">Ed25519</option>
+<option value="rsa-2048">RSA 2048</option>
+<option value="rsa-3072">RSA 3072</option>
+<option value="rsa-4096">RSA 4096</option>
+</select></div>
+<div><b>DNS Name:</b></div><div><input type="text" name="dnsname" size="20" placeholder="optional (server certs)" /></div>
+<div><b>Password:</b></div><div><input type="password" name="pw1" size="20" placeholder="required" /></div>
+<div><b>Re-type Password:</b></div><div><input type="password" name="pw2" size="20" placeholder="required" /></div>
+</div>
+<button onclick="generateKeyAndCert(this.form);">Get Key &amp; Cert</button>
+<button onclick="hideForm();">Cancel</button>
+</form>
+<hr />
+<h2>Option 2</h2>
+<div>Use a Certificate Signing Request. One can be created with openssl, e.g.</div>
+<code>openssl req -newkey rsa:2048 -keyout PRIVATEKEY.key -out CSR.pem</code>
+<div>Paste the CSR below, and click Request.</div>
+<form onsubmit="return false;">
+<textarea name="csr" placeholder="-----BEGIN CERTIFICATE REQUEST-----
+...
+-----END CERTIFICATE REQUEST-----">
+</textarea><br />
+<input type="button" value="Request" onclick="requestCert(this.form.csr.value);" />
+<input type="button" value="Cancel" onclick="hideForm();" />
+</form>
+</div>
+
+<div id="viewcert" style="display: none;">
+<pre id="certpem"></pre>
+<button onclick="hideView();">Close</button>
+</div>
+
+</body>
+</html>

--- a/proxy/internal/pki/certs.js
+++ b/proxy/internal/pki/certs.js
@@ -103,6 +103,7 @@ function generateKeyAndCert(f) {
   const pw = f.pw1.value;
   const fmt = f.format.value;
   const kty = f.keytype.value;
+  const label = f.label.value;
   const dns = f.dnsname.value;
   f.pw1.value = '';
   f.pw2.value = '';
@@ -129,6 +130,11 @@ function generateKeyAndCert(f) {
       p.setAttribute('type', 'hidden');
       p.setAttribute('name', 'keytype');
       p.setAttribute('value', kty);
+      f.appendChild(p);
+      p = document.createElement('input');
+      p.setAttribute('type', 'hidden');
+      p.setAttribute('name', 'label');
+      p.setAttribute('value', label);
       f.appendChild(p);
       p = document.createElement('input');
       p.setAttribute('type', 'hidden');

--- a/proxy/internal/pki/certs.js
+++ b/proxy/internal/pki/certs.js
@@ -1,0 +1,163 @@
+// MIT License
+//
+// Copyright (c) 2023 TTBT Enterprises LLC
+// Copyright (c) 2023 Robin Thellend <rthellend@thellend.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+function requestCert(csr) {
+  fetch('?get=requestCert', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/x-pem-file',
+      'x-csrf-check': '1',
+    },
+    body: csr,
+  })
+  .then(resp => {
+    if (resp.status !== 200 || resp.headers.get('content-type') !== 'application/json') {
+      console.log('Response is not json', resp);
+      throw 'unexpected response from server';
+    }
+    return resp.json();
+  })
+  .then(r => {
+    if (r.result === 'ok') {
+      console.log('Success');
+      document.getElementById('csrform').style.display = 'none';
+      document.getElementById('viewcert').style.display = 'block';
+      document.getElementById('certpem').textContent = r.cert;
+    }
+  })
+  .catch(err => {
+    console.log('Failure', err);
+    alert(err);
+  });
+}
+function revokeCert(sn) {
+  if (!confirm('Revoke certificate with serial number '+sn+'?')) {
+    return;
+  }
+  fetch('?get=revokeCert', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded',
+      'x-csrf-check': '1',
+    },
+    body: 'sn='+encodeURIComponent(sn),
+  })
+  .then(resp => {
+    if (resp.status !== 200 || resp.headers.get('content-type') !== 'application/json') {
+      console.log('Response is not json', resp);
+      throw 'unexpected response from server';
+    }
+    return resp.json();
+  })
+  .then(r => {
+    if (r.result !== 'ok') {
+      throw new Error(r.result);
+    }
+    console.log('Success');
+    window.location.reload();
+  })
+  .catch(err => {
+    console.log('Failure', err);
+    alert(err);
+  });
+}
+function downloadCert(sn) {
+  window.location = '?get=downloadCert&sn='+encodeURIComponent(sn);
+}
+function showForm() {
+  document.getElementById('csrform').style.display = 'block';
+}
+function hideForm() {
+  document.getElementById('csrform').style.display = 'none';
+  window.location.reload();
+}
+function generateKeyAndCert(f) {
+  if (f.pw1.value.length < 6) {
+    alert('Password must be at least 6 characters');
+    return;
+  }
+  if (f.pw1.value !== f.pw2.value) {
+    alert('Passwords don\'t match');
+    return;
+  }
+  const pw = f.pw1.value;
+  const fmt = f.format.value;
+  const kty = f.keytype.value;
+  const dns = f.dnsname.value;
+  f.pw1.value = '';
+  f.pw2.value = '';
+  const path = window.location.pathname + '/generateKeyAndCert';
+  navigator.serviceWorker.register('?get=static&file=sw.js', {scope: path})
+    .then(r => r.update())
+    .then(r => {
+      console.log('Service worker ready');
+      document.getElementById('csrform').style.display = 'none';
+      const f = document.createElement('form');
+      f.setAttribute('method', 'post');
+      f.setAttribute('action', path);
+      let p = document.createElement('input');
+      p.setAttribute('type', 'hidden');
+      p.setAttribute('name', 'password');
+      p.setAttribute('value', pw);
+      f.appendChild(p);
+      p = document.createElement('input');
+      p.setAttribute('type', 'hidden');
+      p.setAttribute('name', 'format');
+      p.setAttribute('value', fmt);
+      f.appendChild(p);
+      p = document.createElement('input');
+      p.setAttribute('type', 'hidden');
+      p.setAttribute('name', 'keytype');
+      p.setAttribute('value', kty);
+      f.appendChild(p);
+      p = document.createElement('input');
+      p.setAttribute('type', 'hidden');
+      p.setAttribute('name', 'dnsname');
+      p.setAttribute('value', dns);
+      f.appendChild(p);
+      document.body.appendChild(f);
+      f.submit();
+    })
+    .catch(err => console.error('Service worker update failed', err))
+}
+function showView(sn) {
+  fetch('?get=downloadCert&sn='+encodeURIComponent(sn))
+  .then(resp => {
+    if (resp.status !== 200 || resp.headers.get('content-type') !== 'application/x-pem-file') {
+      console.log('Response is not pem', resp);
+      throw 'unexpected response from server';
+    }
+    return resp.text();
+  })
+  .then(r => {
+    document.getElementById('viewcert').style.display = 'block';
+    document.getElementById('certpem').textContent = r
+  })
+  .catch(err => {
+    console.log('Failure', err);
+    alert(err);
+  });
+}
+function hideView() {
+  document.getElementById('viewcert').style.display = 'none';
+}

--- a/proxy/internal/pki/clientwasm/impl/impl.go
+++ b/proxy/internal/pki/clientwasm/impl/impl.go
@@ -1,0 +1,126 @@
+// MIT License
+//
+// Copyright (c) 2023 TTBT Enterprises LLC
+// Copyright (c) 2023 Robin Thellend <rthellend@thellend.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package impl
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/openpgp"
+	pkcs12 "software.sslmate.com/src/go-pkcs12"
+
+	"github.com/c2FmZQ/tlsproxy/proxy/internal/pki/keys"
+)
+
+var (
+	privateKeys map[int]keyData
+)
+
+type keyData struct {
+	key      crypto.PrivateKey
+	format   string
+	password string
+}
+
+func MakeCSR(id int, keyType, format, dnsname, password string) ([]byte, error) {
+	privKey, err := keys.GenerateKey(keyType)
+	if err != nil {
+		return nil, err
+	}
+	if privateKeys == nil {
+		privateKeys = make(map[int]keyData)
+	}
+	privateKeys[id] = keyData{
+		key:      privKey,
+		format:   format,
+		password: password,
+	}
+
+	templ := &x509.CertificateRequest{}
+	if dnsname != "" {
+		templ.DNSNames = strings.Fields(strings.ReplaceAll(dnsname, ",", " "))
+	}
+	raw, err := x509.CreateCertificateRequest(rand.Reader, templ, privKey)
+	if err != nil {
+		return nil, fmt.Errorf("x509.CreateCertificateRequest: %v\n", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: raw}), nil
+}
+
+func MakeResponse(id int, pemCert string) ([]byte, string, string, error) {
+	block, _ := pem.Decode([]byte(pemCert))
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil, "", "", errors.New("invalid pem certificate")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, "", "", errors.New("invalid certificate")
+	}
+	sn := hex.EncodeToString(cert.SerialNumber.Bytes())
+	kd, ok := privateKeys[id]
+	if !ok {
+		return nil, "", "", errors.New("invalid id")
+	}
+	delete(privateKeys, id)
+	switch kd.format {
+	case "gpg":
+		b, err := x509.MarshalPKCS8PrivateKey(kd.key)
+		if err != nil {
+			return nil, "", "", fmt.Errorf("x509.MarshalPKCS8PrivateKey: %v\n", err)
+		}
+		var buf bytes.Buffer
+		w, err := openpgp.SymmetricallyEncrypt(&buf, []byte(kd.password), &openpgp.FileHints{FileName: sn + ".pem", ModTime: cert.NotBefore}, nil)
+		if err != nil {
+			return nil, "", "", fmt.Errorf("openpgp.SymmetricallyEncrypt: %v\n", err)
+		}
+		if err := pem.Encode(w, &pem.Block{Type: "PRIVATE KEY", Bytes: b}); err != nil {
+			return nil, "", "", fmt.Errorf("pem.Encode: %v\n", err)
+		}
+		if _, err := w.Write([]byte(pemCert)); err != nil {
+			return nil, "", "", fmt.Errorf("Write: %v\n", err)
+		}
+		if err := w.Close(); err != nil {
+			return nil, "", "", fmt.Errorf("Close: %v\n", err)
+		}
+		return buf.Bytes(), "application/octet-stream", sn + ".pem.gpg", nil
+
+	case "p12":
+		enc := pkcs12.Modern.WithIterations(250000)
+		p12, err := enc.Encode(kd.key, cert, nil, kd.password)
+		if err != nil {
+			return nil, "", "", fmt.Errorf("pkcs12.Encode: %v", err)
+		}
+		return p12, "application/x-pkcs12", sn + ".p12", nil
+
+	default:
+		return nil, "", "", errors.New("unexpected format")
+	}
+}

--- a/proxy/internal/pki/clientwasm/impl/impl.go
+++ b/proxy/internal/pki/clientwasm/impl/impl.go
@@ -28,6 +28,7 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/hex"
 	"encoding/pem"
 	"errors"
@@ -50,7 +51,7 @@ type keyData struct {
 	password string
 }
 
-func MakeCSR(id int, keyType, format, dnsname, password string) ([]byte, error) {
+func MakeCSR(id int, keyType, format, label, dnsname, password string) ([]byte, error) {
 	privKey, err := keys.GenerateKey(keyType)
 	if err != nil {
 		return nil, err
@@ -64,7 +65,9 @@ func MakeCSR(id int, keyType, format, dnsname, password string) ([]byte, error) 
 		password: password,
 	}
 
-	templ := &x509.CertificateRequest{}
+	templ := &x509.CertificateRequest{
+		Subject: pkix.Name{CommonName: label},
+	}
 	if dnsname != "" {
 		templ.DNSNames = strings.Fields(strings.ReplaceAll(dnsname, ",", " "))
 	}

--- a/proxy/internal/pki/clientwasm/impl/impl_test.go
+++ b/proxy/internal/pki/clientwasm/impl/impl_test.go
@@ -39,7 +39,7 @@ func TestKeyTypeFormat(t *testing.T) {
 	for _, tc := range []struct {
 		keyType     string
 		format      string
-		label          string
+		label       string
 		dnsName     string
 		contentType string
 		ext         string

--- a/proxy/internal/pki/clientwasm/impl/impl_test.go
+++ b/proxy/internal/pki/clientwasm/impl/impl_test.go
@@ -39,6 +39,7 @@ func TestKeyTypeFormat(t *testing.T) {
 	for _, tc := range []struct {
 		keyType     string
 		format      string
+		label          string
 		dnsName     string
 		contentType string
 		ext         string
@@ -50,7 +51,7 @@ func TestKeyTypeFormat(t *testing.T) {
 		{keyType: "ed25519", format: "gpg", dnsName: "example.com", contentType: "application/octet-stream", ext: ".pem.gpg"},
 	} {
 		count++
-		csrPEM, err := MakeCSR(count, tc.keyType, tc.format, tc.dnsName, "foo")
+		csrPEM, err := MakeCSR(count, tc.keyType, tc.format, tc.label, tc.dnsName, "foo")
 		if err != nil {
 			t.Fatalf("MakeCSR: %v", err)
 		}

--- a/proxy/internal/pki/clientwasm/impl/impl_test.go
+++ b/proxy/internal/pki/clientwasm/impl/impl_test.go
@@ -1,0 +1,105 @@
+// MIT License
+//
+// Copyright (c) 2023 TTBT Enterprises LLC
+// Copyright (c) 2023 Robin Thellend <rthellend@thellend.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package impl
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+)
+
+func TestKeyTypeFormat(t *testing.T) {
+	count := 0
+	for _, tc := range []struct {
+		keyType     string
+		format      string
+		dnsName     string
+		contentType string
+		ext         string
+	}{
+		{keyType: "ed25519", format: "gpg", contentType: "application/octet-stream", ext: ".pem.gpg"},
+		{keyType: "ecdsa-p521", format: "gpg", contentType: "application/octet-stream", ext: ".pem.gpg"},
+		{keyType: "ecdsa-p256", format: "p12", contentType: "application/x-pkcs12", ext: ".p12"},
+		{keyType: "rsa-2048", format: "p12", contentType: "application/x-pkcs12", ext: ".p12"},
+		{keyType: "ed25519", format: "gpg", dnsName: "example.com", contentType: "application/octet-stream", ext: ".pem.gpg"},
+	} {
+		count++
+		csrPEM, err := MakeCSR(count, tc.keyType, tc.format, tc.dnsName, "foo")
+		if err != nil {
+			t.Fatalf("MakeCSR: %v", err)
+		}
+		block, _ := pem.Decode(csrPEM)
+		if block == nil {
+			t.Fatal("Error decoding PEM CSR")
+		}
+		if got, want := block.Type, "CERTIFICATE REQUEST"; got != want {
+			t.Errorf("PEM type = %s, want %s", got, want)
+		}
+
+		cr, err := x509.ParseCertificateRequest(block.Bytes)
+		if err != nil {
+			t.Fatalf("x509.ParseCertificateRequest: %v", err)
+		}
+
+		_, privKey, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			t.Fatalf("ed25519.GenerateKey: %v", err)
+		}
+		now := time.Now().UTC()
+		sn, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 160))
+		if err != nil {
+			t.Fatalf("rand.Int: %v", err)
+		}
+		templ := &x509.Certificate{
+			SerialNumber:          sn,
+			PublicKeyAlgorithm:    cr.PublicKeyAlgorithm,
+			Subject:               cr.Subject,
+			NotBefore:             now,
+			NotAfter:              now.Add(10 * time.Minute),
+			KeyUsage:              x509.KeyUsageDataEncipherment | x509.KeyUsageDigitalSignature,
+			BasicConstraintsValid: true,
+		}
+		raw, err := x509.CreateCertificate(rand.Reader, templ, templ, cr.PublicKey, privKey)
+		if err != nil {
+			t.Fatalf("x509.CreateCertificate: %v", err)
+		}
+		cert := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: raw})
+
+		_, contentType, fileName, err := MakeResponse(count, string(cert))
+		if err != nil {
+			t.Fatalf("MakeResponse: %v", err)
+		}
+		if got, want := contentType, tc.contentType; got != want {
+			t.Errorf("content-type = %s, want %s", got, want)
+		}
+		if got, want := fileName, hex.EncodeToString(sn.Bytes())+tc.ext; got != want {
+			t.Errorf("fileName = %s, want %s", got, want)
+		}
+	}
+}

--- a/proxy/internal/pki/clientwasm/main.go
+++ b/proxy/internal/pki/clientwasm/main.go
@@ -1,0 +1,122 @@
+// MIT License
+//
+// Copyright (c) 2023 TTBT Enterprises LLC
+// Copyright (c) 2023 Robin Thellend <rthellend@thellend.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+//go:build wasm
+
+// clientwasm implements TLS key generation and PKCS12 packaging in a browser
+// so that the private key is never copied over the network.
+package main
+
+import (
+	"fmt"
+	"net/url"
+	"syscall/js"
+
+	"github.com/c2FmZQ/tlsproxy/proxy/internal/pki/clientwasm/impl"
+)
+
+var (
+	jsUint8Array = js.Global().Get("Uint8Array")
+	jsResponse   = js.Global().Get("Response")
+)
+
+func main() {
+	pkiApp := js.Global().Get("pkiApp")
+	if pkiApp.Type() != js.TypeObject {
+		panic("pkiApp object not found")
+	}
+	ready := pkiApp.Get("pkiwasmIsReady")
+	if ready.Type() != js.TypeFunction {
+		panic("pkiApp.pkiwasmIsReady not found")
+	}
+	pkiApp.Set("makeCertificateRequest", js.FuncOf(makeCSR))
+	pkiApp.Set("makeResponse", js.FuncOf(makeResponse))
+	ready.Invoke()
+	<-make(chan struct{})
+}
+
+func makeCSR(this js.Value, args []js.Value) any {
+	// arg0: id  (a unique ID to match makeCSR with makeP12)
+	// arg2: application/x-www-form-urlencoded arguments
+	if len(args) != 2 || args[0].Type() != js.TypeNumber || args[1].Type() != js.TypeString {
+		fmt.Println("makeCertificateRequest: unexpected arguments")
+		return js.Undefined()
+	}
+	form, err := url.ParseQuery(args[1].String())
+	if err != nil {
+		fmt.Printf("ParseQuery(%q): %v\n", args[1].String(), err)
+		return js.Undefined()
+	}
+	keyType := form.Get("keytype")
+	if keyType == "" {
+		keyType = "ecdsa-p256"
+	}
+	format := form.Get("format")
+	if format == "" {
+		format = "gpg"
+	}
+	password := form.Get("password")
+	if password == "" {
+		fmt.Println("password is missing")
+		return js.Undefined()
+	}
+	resp, err := impl.MakeCSR(args[0].Int(), keyType, format, form.Get("dnsname"), password)
+	if err != nil {
+		fmt.Println(err)
+		return js.Undefined()
+	}
+	return Uint8ArrayFromBytes(resp)
+}
+
+func makeResponse(this js.Value, args []js.Value) any {
+	// arg0: id  (the same id used with makeCSR)
+	// arg1: the pem-encoded cert
+	if len(args) != 2 || args[0].Type() != js.TypeNumber || args[1].Type() != js.TypeString {
+		fmt.Println("makeResponse: unexpected argument")
+		return js.Undefined()
+	}
+	body, contentType, fileName, err := impl.MakeResponse(args[0].Int(), args[1].String())
+	if err != nil {
+		fmt.Println(err)
+		return js.Undefined()
+	}
+
+	return jsResponse.New(
+		Uint8ArrayFromBytes(body),
+		js.ValueOf(map[string]any{
+			"status":     200,
+			"statusText": "OK",
+			"headers": map[string]any{
+				"content-type":        contentType,
+				"content-disposition": `attachment; filename="` + fileName + `"`,
+				"cache-control":       "private, no-store",
+			},
+		}),
+	)
+}
+
+func Uint8ArrayFromBytes(in []byte) js.Value {
+	out := jsUint8Array.New(js.ValueOf(len(in)))
+	js.CopyBytesToJS(out, in)
+	return out
+}

--- a/proxy/internal/pki/clientwasm/main.go
+++ b/proxy/internal/pki/clientwasm/main.go
@@ -80,7 +80,7 @@ func makeCSR(this js.Value, args []js.Value) any {
 		fmt.Println("password is missing")
 		return js.Undefined()
 	}
-	resp, err := impl.MakeCSR(args[0].Int(), keyType, format, form.Get("dnsname"), password)
+	resp, err := impl.MakeCSR(args[0].Int(), keyType, format, form.Get("label"), form.Get("dnsname"), password)
 	if err != nil {
 		fmt.Println(err)
 		return js.Undefined()

--- a/proxy/internal/pki/http.go
+++ b/proxy/internal/pki/http.go
@@ -378,13 +378,14 @@ func (m *PKIManager) handleRequestCert(w http.ResponseWriter, req *http.Request)
 	cr := &x509.CertificateRequest{
 		PublicKeyAlgorithm: in.PublicKeyAlgorithm,
 		PublicKey:          in.PublicKey,
+		Subject:            pkix.Name{CommonName: subject},
 		EmailAddresses: []string{
 			subject,
 		},
 		DNSNames: in.DNSNames,
 	}
-	if name, ok := claims["name"].(string); ok {
-		cr.Subject = pkix.Name{CommonName: name}
+	if in.Subject.CommonName != "" {
+		cr.Subject.CommonName += "::" + in.Subject.CommonName
 	}
 	cert, err := m.IssueCertificate(cr)
 	if err != nil {

--- a/proxy/internal/pki/http.go
+++ b/proxy/internal/pki/http.go
@@ -1,0 +1,533 @@
+// MIT License
+//
+// Copyright (c) 2023 TTBT Enterprises LLC
+// Copyright (c) 2023 Robin Thellend <rthellend@rthellend.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+//go:generate ./build-wasm.sh
+
+package pki
+
+import (
+	"compress/bzip2"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"embed"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"html/template"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/ocsp"
+)
+
+//go:embed certs.html
+var embedCerts string
+var certsTemplate *template.Template
+
+//go:embed certs.js sw.js style.css pki.wasm.bz2 wasm_exec.js
+var staticFiles embed.FS
+var staticEtags map[string]string
+
+func init() {
+	certsTemplate = template.Must(template.New("pki-certs").Parse(embedCerts))
+	staticEtags = make(map[string]string)
+	d, err := staticFiles.ReadDir(".")
+	if err != nil {
+		panic(err)
+	}
+	for _, e := range d {
+		b, err := staticFiles.ReadFile(e.Name())
+		if err != nil {
+			panic(err)
+		}
+		h := sha256.Sum256(b)
+		staticEtags[e.Name()] = `"` + hex.EncodeToString(h[:]) + `"`
+	}
+}
+
+// ServeCACert sends the CA's certificate.
+func (m *PKIManager) ServeCACert(w http.ResponseWriter, req *http.Request) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ca, exists := m.db.CAs[m.opts.Name]
+	if !exists || ca.CACert == nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("cache-control", "public, max-age=86400")
+	if strings.HasSuffix(req.URL.Path, ".pem") {
+		w.Header().Set("content-type", "application/x-pem-file")
+		out := ca.CACert.pem()
+		for _, c := range ca.DelegateCerts {
+			out = append(out, c.pem()...)
+		}
+		etag(w, req, out)
+		return
+	}
+	w.Header().Set("content-type", "application/x-x509-ca-cert")
+	out := ca.CACert.Raw
+	for _, c := range ca.DelegateCerts {
+		out = append(out, c.Raw...)
+	}
+	etag(w, req, out)
+}
+
+// ServeCRL sends the revocation list.
+func (m *PKIManager) ServeCRL(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("cache-control", "public, max-age=1800")
+	if strings.HasSuffix(req.URL.Path, ".pem") {
+		b, err := m.RevocationListPEM()
+		if err != nil {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("content-type", "application/x-pem-file")
+		etag(w, req, b)
+		return
+	}
+	_, b, err := m.RevocationList()
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("content-type", "application/x-pkcs7-crl")
+	etag(w, req, b)
+}
+
+// ServeOCSP implements the OCSP protocol for this CA.
+// https://www.rfc-editor.org/rfc/rfc6960.html
+func (m *PKIManager) ServeOCSP(w http.ResponseWriter, req *http.Request) {
+	var raw []byte
+	switch req.Method {
+	case http.MethodGet:
+		// https://www.rfc-editor.org/rfc/rfc6960.html#page-30
+		off := strings.LastIndex(req.URL.Path, "/")
+		if off < 0 {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		data, err := url.PathUnescape(req.URL.Path[off+1:])
+		if err != nil {
+			log.Printf("ERR url.PathUnescape: %v", err)
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		// Accept std and url base64 encoding, with or without padding.
+		data = strings.ReplaceAll(data, " ", "-")
+		data = strings.ReplaceAll(data, "+", "-")
+		data = strings.ReplaceAll(data, "/", "_")
+		data = strings.TrimRight(data, "=")
+		if raw, err = base64.RawURLEncoding.DecodeString(data); err != nil {
+			log.Printf("ERR base64: %v", err)
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+
+	case http.MethodPost:
+		// https://www.rfc-editor.org/rfc/rfc6960.html#page-30
+		if req.Header.Get("content-type") != "application/ocsp-request" {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		const maxSize = 4096
+		var err error
+		if raw, err = io.ReadAll(&io.LimitedReader{R: req.Body, N: maxSize}); err != nil || len(raw) == maxSize {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+
+	default:
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	ocspReq, err := ocsp.ParseRequest(raw)
+	if err != nil {
+		log.Printf("ERR ocsp.ParseRequest: %v", err)
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	resp, err := m.OCSPResponse(ocspReq)
+	if err != nil {
+		log.Printf("ERR OCSPResponse: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("cache-control", "public, max-age=1800")
+	w.Header().Set("content-type", "application/ocsp-response")
+	w.Write(resp)
+}
+
+func (m *PKIManager) ServeCertificateManagement(w http.ResponseWriter, req *http.Request) {
+	req.ParseForm()
+
+	enableAdmin := req.Form.Get("admin")
+	claims := m.opts.ClaimsFromCtx(req.Context())
+	if claims == nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	subject, _ := claims.GetSubject()
+	isAdmin := enableAdmin != "" && slices.Contains(m.opts.Admins, subject)
+
+	mode := req.Form.Get("get")
+	switch mode {
+	case "requestCert":
+		m.handleRequestCert(w, req)
+		return
+	case "revokeCert":
+		m.handleRevokeCert(w, req, isAdmin)
+		return
+	case "downloadCert":
+		m.handleDownloadCert(w, req)
+		return
+	case "static":
+		m.handleStaticFile(w, req)
+		return
+	default:
+		log.Printf("ERR unexpected mode: %v", mode)
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	case "":
+		// Continue below
+	}
+	statusFilter := strings.ToLower(req.Form.Get("status"))
+	ownerFilter := strings.ToLower(req.Form.Get("owner"))
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var currentSN string
+	if req.TLS != nil && len(req.TLS.PeerCertificates) > 0 {
+		currentSN = bytesToHex(req.TLS.PeerCertificates[0].SerialNumber.Bytes())
+	}
+
+	ca, exists := m.db.CAs[m.opts.Name]
+	if !exists || ca.CACert == nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	caCert, err := ca.CACert.parse()
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	type cert struct {
+		SN             string
+		Subject        string
+		EmailAddresses []string
+		DNSNames       []string
+		URIs           []*url.URL
+		NotBefore      string
+		NotAfter       string
+		RevocationTime string
+		ExtKeyUsage    string
+		IsCA           bool
+		Status         string
+		UsedNow        bool
+		CanRevoke      bool
+	}
+	certs := make([]cert, 0, len(ca.IssuedCerts))
+	now := time.Now().UTC()
+
+	for _, ic := range ca.IssuedCerts {
+		c, err := ic.parse()
+		if err != nil {
+			log.Printf("ERR x509.ParseCertificate: %v", err)
+			continue
+		}
+		if ownerFilter != "all" && !slices.Contains(c.EmailAddresses, subject) {
+			continue
+		}
+		var revTime time.Time
+		if r := ic.Revocation; r != nil {
+			revTime = r.Time
+		}
+		status := "Valid"
+		if !revTime.IsZero() {
+			status = "Revoked"
+		} else if now.After(c.NotAfter) {
+			status = "Expired"
+		}
+		if (statusFilter == "" || statusFilter == "valid") && status != "Valid" {
+			continue
+		}
+		if statusFilter == "revoked" && status != "Revoked" {
+			continue
+		}
+		if statusFilter == "expired" && status != "Expired" {
+			continue
+		}
+		var eku []string
+		for _, v := range c.ExtKeyUsage {
+			switch v {
+			case x509.ExtKeyUsageServerAuth:
+				eku = append(eku, "ServerAuth")
+			case x509.ExtKeyUsageClientAuth:
+				eku = append(eku, "ClientAuth")
+			case x509.ExtKeyUsageOCSPSigning:
+				eku = append(eku, "OCSPSigning")
+			}
+		}
+		certs = append(certs, cert{
+			SN:             ic.SerialNumber,
+			Subject:        c.Subject.String(),
+			EmailAddresses: c.EmailAddresses,
+			DNSNames:       c.DNSNames,
+			URIs:           c.URIs,
+			NotBefore:      c.NotBefore.Format(time.DateTime),
+			NotAfter:       c.NotAfter.Format(time.DateTime),
+			RevocationTime: revTime.Format(time.DateTime),
+			ExtKeyUsage:    strings.Join(eku, ", "),
+			IsCA:           c.IsCA,
+			Status:         status,
+			UsedNow:        currentSN == ic.SerialNumber,
+			CanRevoke:      !c.IsCA && (isAdmin || slices.Contains(c.EmailAddresses, subject)),
+		})
+	}
+	slices.Reverse(certs)
+
+	data := struct {
+		Status         string
+		Owner          string
+		Subject        string
+		CASubject      string
+		CASN           string
+		CASubjectKeyId string
+		Certs          []cert
+	}{
+		Status:         statusFilter,
+		Owner:          ownerFilter,
+		Subject:        subject,
+		CASubject:      caCert.Subject.String(),
+		CASN:           bytesToHex(caCert.SerialNumber.Bytes()),
+		CASubjectKeyId: bytesToHex(caCert.SubjectKeyId),
+		Certs:          certs,
+	}
+	w.Header().Set("X-Frame-Options", "DENY")
+	certsTemplate.Execute(w, data)
+}
+
+func (m *PKIManager) handleRequestCert(w http.ResponseWriter, req *http.Request) {
+	claims := m.opts.ClaimsFromCtx(req.Context())
+	if claims == nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	subject, _ := claims.GetSubject()
+
+	if req.Method != http.MethodPost {
+		log.Printf("ERR method: %v", req.Method)
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if v := req.Header.Get("x-csrf-check"); v != "1" {
+		log.Printf("ERR x-csrf-check: %v", v)
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if ct := req.Header.Get("content-type"); ct != "application/x-pem-file" {
+		log.Printf("ERR content-type: %v", ct)
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	defer req.Body.Close()
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		log.Printf("ERR body: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	block, _ := pem.Decode(body)
+	if block == nil {
+		log.Print("ERR no pem block")
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	in, err := m.ValidateCertificateRequest(block.Bytes)
+	if err != nil {
+		log.Printf("ERR ValidateCertificateRequest: %v", err)
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	cr := &x509.CertificateRequest{
+		PublicKeyAlgorithm: in.PublicKeyAlgorithm,
+		PublicKey:          in.PublicKey,
+		EmailAddresses: []string{
+			subject,
+		},
+		DNSNames: in.DNSNames,
+	}
+	if name, ok := claims["name"].(string); ok {
+		cr.Subject = pkix.Name{CommonName: name}
+	}
+	cert, err := m.IssueCertificate(cr)
+	if err != nil {
+		log.Printf("ERR body: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("content-type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"result": "ok",
+		"cert":   string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert})),
+	})
+}
+
+func (m *PKIManager) handleRevokeCert(w http.ResponseWriter, req *http.Request, isAdmin bool) {
+	claims := m.opts.ClaimsFromCtx(req.Context())
+	if claims == nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	subject, _ := claims.GetSubject()
+
+	if req.Method != http.MethodPost {
+		log.Printf("ERR method: %v", req.Method)
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if v := req.Header.Get("x-csrf-check"); v != "1" {
+		log.Printf("ERR x-csrf-check: %v", v)
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+
+	c, err := m.findCert(req.Form.Get("sn"))
+	if err != nil {
+		log.Printf("ERR findCert: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	now := time.Now().UTC()
+	if now.After(c.NotAfter) {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if isAdmin || !slices.Contains(c.EmailAddresses, subject) {
+		w.Header().Set("content-type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"result": "permission denied",
+		})
+		return
+	}
+	if err := m.RevokeCertificate(c.SerialNumber, RevokeReasonUnspecified); err != nil {
+		log.Printf("ERR m.RevokeCertificate: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("content-type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"result": "ok",
+	})
+}
+
+func (m *PKIManager) handleDownloadCert(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodGet {
+		log.Printf("ERR method: %v", req.Method)
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+
+	sn := req.Form.Get("sn")
+	c, err := m.findCert(sn)
+	if err != nil {
+		log.Printf("ERR findCert: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("content-type", "application/x-pem-file")
+	w.Header().Set("content-disposition", "attachment; filename=\""+strings.ReplaceAll(sn, ":", "")+".pem\"")
+	pem.Encode(w, &pem.Block{Type: "CERTIFICATE", Bytes: c.Raw})
+}
+
+func (m *PKIManager) handleStaticFile(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodGet {
+		log.Printf("ERR method: %v", req.Method)
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	file := req.Form.Get("file")
+	r, err := staticFiles.Open(file)
+	if err != nil {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	defer r.Close()
+	var rr io.Reader = r
+	if strings.HasSuffix(file, ".bz2") {
+		rr = bzip2.NewReader(r)
+	}
+	if strings.HasSuffix(file, ".css") {
+		w.Header().Set("content-type", "text/css")
+	} else if strings.HasSuffix(file, ".js") {
+		w.Header().Set("content-type", "text/javascript")
+	}
+	etag, ok := staticEtags[file]
+	if ok {
+		w.Header().Set("Etag", etag)
+		if e := req.Header.Get("If-None-Match"); e == etag {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+	}
+	io.Copy(w, rr)
+}
+
+func (m *PKIManager) findCert(sn string) (*x509.Certificate, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ca, exists := m.db.CAs[m.opts.Name]
+	if !exists || ca.CACert == nil {
+		return nil, errNotFound
+	}
+	i := slices.IndexFunc(ca.IssuedCerts, func(c *certificate) bool {
+		return c.SerialNumber == sn
+	})
+	if i < 0 {
+		return nil, errNotFound
+	}
+	if ca.IssuedCerts[i].Revocation != nil {
+		return nil, errNotFound
+	}
+	return ca.IssuedCerts[i].parse()
+}
+
+func etag(w http.ResponseWriter, req *http.Request, body []byte) {
+	sum := sha256.Sum256(body)
+	etag := `"` + hex.EncodeToString(sum[:]) + `"`
+	w.Header().Set("Etag", etag)
+
+	if e := req.Header.Get("If-None-Match"); e == etag {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+	w.Write(body)
+}

--- a/proxy/internal/pki/http.go
+++ b/proxy/internal/pki/http.go
@@ -239,6 +239,7 @@ func (m *PKIManager) ServeCertificateManagement(w http.ResponseWriter, req *http
 
 	type cert struct {
 		SN             string
+		PublicKey      string
 		Subject        string
 		EmailAddresses []string
 		DNSNames       []string
@@ -294,8 +295,14 @@ func (m *PKIManager) ServeCertificateManagement(w http.ResponseWriter, req *http
 				eku = append(eku, "OCSPSigning")
 			}
 		}
+		pubKeyBytes, err := publicKeyFromCert(c)
+		if err != nil {
+			log.Printf("ERR publicKeyFromCert: %v", err)
+			continue
+		}
 		certs = append(certs, cert{
 			SN:             ic.SerialNumber,
+			PublicKey:      c.PublicKeyAlgorithm.String() + " " + bytesToHex(pubKeyBytes),
 			Subject:        c.Subject.String(),
 			EmailAddresses: c.EmailAddresses,
 			DNSNames:       c.DNSNames,

--- a/proxy/internal/pki/pki.go
+++ b/proxy/internal/pki/pki.go
@@ -1,0 +1,751 @@
+// MIT License
+//
+// Copyright (c) 2023 TTBT Enterprises LLC
+// Copyright (c) 2023 Robin Thellend <rthellend@rthellend.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Package pki implements a simple Public Key Infrastructure (PKI) manager that
+// can issue and revoke X.509 certificates.
+package pki
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/sha256"
+	_ "crypto/sha512"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/c2FmZQ/storage"
+	jwt "github.com/golang-jwt/jwt/v5"
+	"golang.org/x/crypto/ocsp"
+
+	"github.com/c2FmZQ/tlsproxy/proxy/internal/pki/keys"
+)
+
+const (
+	pkiFile = "pki"
+
+	// https://www.rfc-editor.org/rfc/rfc5280.html#section-5.3.1
+	RevokeReasonUnspecified          = 0
+	RevokeReasonKeyCompromise        = 1
+	RevokeReasonCACompromise         = 2
+	RevokeReasonAffiliationChanged   = 3
+	RevokeReasonSuperseded           = 4
+	RevokeReasonCessationOfOperation = 5
+	RevokeReasonCertificateHold      = 6
+	// value 7 is not used
+	RevokeReasonRemoveFromCRL       = 8
+	RevokeReasonPriviliegeWithDrawn = 9
+	RevokeReasonAACompromise        = 10
+
+	crlRefreshPeriod    = time.Hour
+	caCertLifetime      = 10 * 365 * 24 * time.Hour
+	caDelegateLifetime  = 10 * 24 * time.Hour
+	issuedCertsLifetime = 10 * 365 * 24 * time.Hour
+	maxNumCRL           = 128
+)
+
+var (
+	errAlreadyExists = errors.New("already exists")
+	errNotFound      = errors.New("not found")
+)
+
+// Options are used to configure the PKI manager.
+type Options struct {
+	// Name is the names of the PKI manager.
+	Name string
+	// KeyType is one of ed25519, rsa-2048, rsa-4096, ecdsa-p256, etc.
+	// Defaults to ecdsa-p256.
+	KeyType string
+	// Endpoint is the URL that serves the PKI web pages.
+	Endpoint string
+	// IssuingCertificateURL is a list of URLs that serve the CA certificate.
+	IssuingCertificateURL []string
+	// CRLDistributionPoints is a list of URLs that server this CA's
+	// Certificate Revocation List.
+	CRLDistributionPoints []string
+	// OCSPServer is a list of URLs that serve the Online Certificate Status
+	// Protocol (OCSP) for this CA.
+	// https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol
+	OCSPServer []string
+	// Admins is the of users who are allowed to perform administrative
+	// tasks.
+	Admins []string
+	// Store is used to store the PKI manager's data.
+	Store *storage.Storage
+	// EventRecorder is used to record events.
+	EventRecorder interface {
+		Record(string)
+	}
+	// ClaimsFromCtx returns jwt claims for the current user.
+	ClaimsFromCtx func(context.Context) jwt.MapClaims
+}
+
+// New returns a new initialized PKI manager. The Certificate Authority's key
+// and certificate are created the first time New is called for a given name.
+func New(opts Options) (*PKIManager, error) {
+	m := &PKIManager{
+		opts: opts,
+	}
+	if m.opts.KeyType == "" {
+		m.opts.KeyType = "ecdsa-p256"
+	}
+	m.opts.Store.CreateEmptyFile(pkiFile, &m.db)
+	if err := m.opts.Store.ReadDataFile(pkiFile, &m.db); err != nil {
+		return nil, err
+	}
+	if err := m.initCA(); err != nil && err != storage.ErrRolledBack {
+		return nil, err
+	}
+	return m, nil
+}
+
+// PKIManager implements a simple Public Key Infrastructure (PKI) manager that
+// can issue and revoke X.509 certificates.
+type PKIManager struct {
+	opts Options
+	mu   sync.Mutex
+	db   struct {
+		CAs map[string]*certificateAuthority
+	}
+}
+
+type certificateAuthority struct {
+	Name            string
+	PrivateKey      []byte
+	CACert          *certificate
+	DelegateKey     []byte
+	DelegateCerts   []*certificate
+	IssuedCerts     []*certificate
+	CRLNumber       int64
+	RevocationLists []revocationList
+	Revoked         map[string]bool
+}
+
+type certificate struct {
+	SHA256       string
+	SerialNumber string
+	Raw          []byte
+	Revocation   *revocation
+
+	cert *x509.Certificate
+}
+
+func (c *certificate) parse() (*x509.Certificate, error) {
+	if c.cert != nil {
+		return c.cert, nil
+	}
+	cert, err := x509.ParseCertificate(c.Raw)
+	if err != nil {
+		return nil, err
+	}
+	c.cert = cert
+	return c.cert, nil
+}
+
+func (c *certificate) pem() []byte {
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: c.Raw,
+	})
+}
+
+func (c *certificate) revoke(code int) {
+	c.Revocation = &revocation{
+		Time:       time.Now().UTC().Truncate(time.Second),
+		ReasonCode: code,
+	}
+}
+
+type revocation struct {
+	Time       time.Time
+	ReasonCode int
+}
+
+type revocationList struct {
+	RawCert []byte
+	RawCRL  []byte
+}
+
+func (m *PKIManager) initCA() (retErr error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	commit, err := m.opts.Store.OpenForUpdate(pkiFile, &m.db)
+	if err != nil {
+		return err
+	}
+	defer commit(false, &retErr)
+	var changed bool
+	if m.db.CAs == nil {
+		m.db.CAs = make(map[string]*certificateAuthority)
+	}
+
+	ca, exists := m.db.CAs[m.opts.Name]
+	if !exists {
+		ca = &certificateAuthority{
+			Name: m.opts.Name,
+		}
+		m.db.CAs[m.opts.Name] = ca
+		changed = true
+	}
+
+	if len(ca.PrivateKey) == 0 {
+		privKey, err := keys.GenerateKey(m.opts.KeyType)
+		if err != nil {
+			return err
+		}
+		keyBytes, err := x509.MarshalPKCS8PrivateKey(privKey)
+		if err != nil {
+			return fmt.Errorf("x509.MarshalPKCS8PrivateKey: %v", err)
+		}
+		ca.PrivateKey = keyBytes
+		changed = true
+	}
+
+	type privateKey interface {
+		Public() crypto.PublicKey
+	}
+	pk, err := x509.ParsePKCS8PrivateKey(ca.PrivateKey)
+	if err != nil {
+		return err
+	}
+	privKey, ok := pk.(privateKey)
+	if !ok {
+		return fmt.Errorf("unexpected private key type %T", pk)
+	}
+
+	now := time.Now().UTC()
+	var needCert bool
+	if ca.CACert == nil {
+		needCert = true
+	} else {
+		cert, err := ca.CACert.parse()
+		if err != nil {
+			return err
+		}
+		if cert.NotBefore.Add(cert.NotAfter.Sub(cert.NotBefore) / 2).Before(now) {
+			needCert = true
+		}
+	}
+
+	if needCert {
+		sn, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 160))
+		if err != nil {
+			return err
+		}
+		templ := &x509.Certificate{
+			SerialNumber:          sn,
+			Issuer:                pkix.Name{CommonName: m.opts.Name},
+			Subject:               pkix.Name{CommonName: m.opts.Name},
+			NotBefore:             now,
+			NotAfter:              now.Add(caCertLifetime),
+			KeyUsage:              x509.KeyUsageCertSign,
+			BasicConstraintsValid: true,
+			IsCA:                  true,
+			MaxPathLenZero:        true,
+			IssuingCertificateURL: m.opts.IssuingCertificateURL,
+			CRLDistributionPoints: m.opts.CRLDistributionPoints,
+			OCSPServer:            m.opts.OCSPServer,
+		}
+		raw, err := x509.CreateCertificate(rand.Reader, templ, templ, privKey.Public(), privKey)
+		if err != nil {
+			return fmt.Errorf("x509.CreateCertificate: %w", err)
+		}
+		h256 := sha256.Sum256(raw)
+
+		c := &certificate{
+			SHA256:       bytesToHex(h256[:]),
+			SerialNumber: bytesToHex(sn.Bytes()),
+			Raw:          raw,
+		}
+		// Keep most recent first.
+		ca.CACert = c
+		ca.IssuedCerts = append(ca.IssuedCerts, c)
+		changed = true
+	}
+	return commit(changed, nil)
+}
+
+func (m *PKIManager) maybeRotateDelegateCert() error {
+	ca, exists := m.db.CAs[m.opts.Name]
+	if !exists {
+		return errors.New("no ca")
+	}
+	now := time.Now().UTC()
+
+	var needUpdate bool
+	if len(ca.DelegateCerts) == 0 {
+		needUpdate = true
+	} else {
+		c, err := ca.DelegateCerts[0].parse()
+		if err != nil || c.NotBefore.Add(c.NotAfter.Sub(c.NotBefore)/2).Before(now) {
+			needUpdate = true
+		}
+	}
+	if !needUpdate {
+		return nil
+	}
+
+	caCert, err := ca.CACert.parse()
+	if err != nil {
+		return err
+	}
+
+	delegateKey, err := keys.GenerateKey(m.opts.KeyType)
+	if err != nil {
+		return err
+	}
+	keyBytes, err := x509.MarshalPKCS8PrivateKey(delegateKey)
+	if err != nil {
+		return fmt.Errorf("x509.MarshalPKCS8PrivateKey: %v", err)
+	}
+
+	sn, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 160))
+	if err != nil {
+		return err
+	}
+	templ := &x509.Certificate{
+		SerialNumber: sn,
+		PublicKey:    delegateKey.(crypto.Signer).Public(),
+		Issuer:       caCert.Subject,
+		Subject:      pkix.Name{CommonName: m.opts.Name + " CRL OCSP"},
+		NotBefore:    now,
+		NotAfter:     now.Add(caDelegateLifetime),
+		KeyUsage:     x509.KeyUsageCRLSign,
+		ExtraExtensions: []pkix.Extension{
+			// id-pkix-ocsp-nocheck
+			pkix.Extension{Id: asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 48, 1, 5}},
+		},
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageOCSPSigning},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		IssuingCertificateURL: m.opts.IssuingCertificateURL,
+		CRLDistributionPoints: m.opts.CRLDistributionPoints,
+		OCSPServer:            m.opts.OCSPServer,
+	}
+	_, err = m.signCertificate(templ, func(c *certificate) error {
+		ca := m.db.CAs[m.opts.Name]
+		ca.DelegateKey = keyBytes
+		old := ca.DelegateCerts
+		ca.DelegateCerts = make([]*certificate, 0, 2)
+		ca.DelegateCerts = append(ca.DelegateCerts, c)
+		if len(old) > 0 {
+			ca.DelegateCerts = append(ca.DelegateCerts, old[0])
+		}
+		return nil
+	})
+	return err
+}
+
+// RevocationListPEM returns the current revocation list, PEM encoded.
+func (m *PKIManager) RevocationListPEM() ([]byte, error) {
+	cert, crl, err := m.RevocationList()
+	if err != nil {
+		return nil, err
+	}
+	var out bytes.Buffer
+	pem.Encode(&out, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert,
+	})
+	pem.Encode(&out, &pem.Block{
+		Type:  "X509 CRL",
+		Bytes: crl,
+	})
+	return out.Bytes(), nil
+}
+
+// RevocationList returns the current revocation list.
+func (m *PKIManager) RevocationList() (cert, crl []byte, retErr error) {
+	if err := m.maybeRotateDelegateCert(); err != nil {
+		return nil, nil, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	commit, err := m.opts.Store.OpenForUpdate(pkiFile, &m.db)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() {
+		commit(false, &retErr)
+		if retErr == storage.ErrRolledBack {
+			retErr = nil
+		}
+	}()
+
+	ca, exists := m.db.CAs[m.opts.Name]
+	if !exists {
+		return nil, nil, errNotFound
+	}
+	now := time.Now().UTC()
+
+	if len(ca.RevocationLists) > 0 {
+		var lastRevocation time.Time
+		for _, c := range ca.IssuedCerts {
+			if c.Revocation != nil && c.Revocation.Time.After(lastRevocation) {
+				lastRevocation = c.Revocation.Time
+			}
+		}
+		last := ca.RevocationLists[len(ca.RevocationLists)-1]
+		rl, err := x509.ParseRevocationList(last.RawCRL)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !rl.ThisUpdate.Before(lastRevocation) && rl.NextUpdate.Add(crlRefreshPeriod/2).After(now) {
+			return last.RawCert, rl.Raw, nil
+		}
+	}
+
+	signCert, err := ca.DelegateCerts[0].parse()
+	if err != nil {
+		return nil, nil, err
+	}
+	ca.CRLNumber++
+	rl := &x509.RevocationList{
+		Issuer:     signCert.Subject,
+		Number:     big.NewInt(ca.CRLNumber),
+		ThisUpdate: now,
+		NextUpdate: now.Add(crlRefreshPeriod),
+	}
+	for _, c := range ca.IssuedCerts {
+		if c.Revocation == nil {
+			continue
+		}
+		cert, err := c.parse()
+		if err != nil {
+			return nil, nil, err
+		}
+		if now.After(cert.NotAfter) {
+			continue
+		}
+		rl.RevokedCertificateEntries = append(rl.RevokedCertificateEntries, x509.RevocationListEntry{
+			SerialNumber:   cert.SerialNumber,
+			RevocationTime: c.Revocation.Time,
+			ReasonCode:     c.Revocation.ReasonCode,
+		})
+	}
+
+	key, err := x509.ParsePKCS8PrivateKey(ca.DelegateKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	signer, ok := key.(crypto.Signer)
+	if !ok {
+		return nil, nil, errors.New("invalid private key")
+	}
+	if crl, err = x509.CreateRevocationList(rand.Reader, rl, signCert, signer); err != nil {
+		return nil, nil, err
+	}
+	ca.RevocationLists = append(ca.RevocationLists, revocationList{
+		RawCert: signCert.Raw,
+		RawCRL:  crl,
+	})
+	if n := len(ca.RevocationLists) - maxNumCRL; n > 0 {
+		ca.RevocationLists = ca.RevocationLists[n:]
+	}
+
+	if err := commit(true, nil); err != nil {
+		return nil, nil, err
+	}
+	return signCert.Raw, crl, nil
+}
+
+// IsRevoked returns whether the certificate with this serial number of revoked.
+func (m *PKIManager) IsRevoked(serialNumber *big.Int) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ca, exists := m.db.CAs[m.opts.Name]
+	if !exists {
+		return false
+	}
+	return ca.Revoked[bytesToHex(serialNumber.Bytes())]
+}
+
+// OCSPResponse creates an OCSP Response from the given request.
+func (m *PKIManager) OCSPResponse(req *ocsp.Request) ([]byte, error) {
+	if !req.HashAlgorithm.Available() {
+		return nil, errors.New("invalid hash algorithn")
+	}
+	if err := m.maybeRotateDelegateCert(); err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ca, exists := m.db.CAs[m.opts.Name]
+	if !exists {
+		return nil, errNotFound
+	}
+	caCert, err := ca.CACert.parse()
+	if err != nil {
+		return nil, err
+	}
+	delegateCert, err := ca.DelegateCerts[0].parse()
+	if err != nil {
+		return nil, err
+	}
+
+	var pkInfo struct {
+		Algorithm pkix.AlgorithmIdentifier
+		PublicKey asn1.BitString
+	}
+	if _, err := asn1.Unmarshal(caCert.RawSubjectPublicKeyInfo, &pkInfo); err != nil {
+		return nil, err
+	}
+
+	key, err := x509.ParsePKCS8PrivateKey(ca.DelegateKey)
+	if err != nil {
+		return nil, err
+	}
+	signer, ok := key.(crypto.Signer)
+	if !ok {
+		return nil, errors.New("invalid private key")
+	}
+
+	h := req.HashAlgorithm.New()
+	h.Write(pkInfo.PublicKey.RightAlign())
+	pubKeyHash := h.Sum(nil)
+	h.Reset()
+	h.Write(caCert.RawSubject)
+	subjectHash := h.Sum(nil)
+
+	snh := bytesToHex(req.SerialNumber.Bytes())
+	idx := slices.IndexFunc(ca.IssuedCerts, func(c *certificate) bool {
+		return c.SerialNumber == snh
+	})
+
+	now := time.Now().UTC()
+
+	if bytes.Compare(req.IssuerNameHash, subjectHash[:]) != 0 || bytes.Compare(req.IssuerKeyHash, pubKeyHash[:]) != 0 {
+		return ocsp.CreateResponse(caCert, delegateCert, ocsp.Response{
+			Status:       ocsp.Unknown,
+			SerialNumber: req.SerialNumber,
+			ThisUpdate:   now,
+			NextUpdate:   now.Add(crlRefreshPeriod),
+			IssuerHash:   crypto.SHA256,
+			Certificate:  delegateCert,
+		}, signer)
+	}
+	if idx < 0 {
+		return ocsp.CreateResponse(caCert, delegateCert, ocsp.Response{
+			Status:           ocsp.Revoked,
+			SerialNumber:     req.SerialNumber,
+			ThisUpdate:       now,
+			NextUpdate:       now.Add(crlRefreshPeriod),
+			RevokedAt:        now,
+			RevocationReason: RevokeReasonCertificateHold,
+			IssuerHash:       crypto.SHA256,
+			Certificate:      delegateCert,
+		}, signer)
+	}
+	if rev := ca.IssuedCerts[idx].Revocation; rev != nil {
+		return ocsp.CreateResponse(caCert, delegateCert, ocsp.Response{
+			Status:           ocsp.Revoked,
+			SerialNumber:     req.SerialNumber,
+			ThisUpdate:       now,
+			NextUpdate:       now.Add(crlRefreshPeriod),
+			RevokedAt:        rev.Time,
+			RevocationReason: rev.ReasonCode,
+			IssuerHash:       crypto.SHA256,
+			Certificate:      delegateCert,
+		}, signer)
+	}
+	return ocsp.CreateResponse(caCert, delegateCert, ocsp.Response{
+		Status:       ocsp.Good,
+		SerialNumber: req.SerialNumber,
+		ThisUpdate:   now,
+		NextUpdate:   now.Add(crlRefreshPeriod),
+		IssuerHash:   crypto.SHA256,
+		Certificate:  delegateCert,
+	}, signer)
+}
+
+// RevokeCertificate revokes the certificate with this serial number and set the
+// reason code.
+func (m *PKIManager) RevokeCertificate(serialNumber *big.Int, reasonCode int) (retErr error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	commit, err := m.opts.Store.OpenForUpdate(pkiFile, &m.db)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		commit(false, &retErr)
+		if retErr == storage.ErrRolledBack {
+			retErr = nil
+		}
+	}()
+
+	ca, exists := m.db.CAs[m.opts.Name]
+	if !exists {
+		return errNotFound
+	}
+	snh := bytesToHex(serialNumber.Bytes())
+	for _, c := range ca.IssuedCerts {
+		if c.SerialNumber == snh {
+			c.revoke(reasonCode)
+			if ca.Revoked == nil {
+				ca.Revoked = make(map[string]bool)
+			}
+			ca.Revoked[snh] = true
+			return commit(true, nil)
+		}
+	}
+	return errNotFound
+}
+
+// CACert returns the CA's certificate.
+func (m *PKIManager) CACert() (*x509.Certificate, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ca, exists := m.db.CAs[m.opts.Name]
+	if !exists {
+		return nil, errNotFound
+	}
+	return ca.CACert.parse()
+}
+
+// ValidateCertificateRequest parses and validates a certificate signing
+// request.
+func (m *PKIManager) ValidateCertificateRequest(csr []byte) (*x509.CertificateRequest, error) {
+	cr, err := x509.ParseCertificateRequest(csr)
+	if err != nil {
+		return nil, err
+	}
+	if err := cr.CheckSignature(); err != nil {
+		return nil, err
+	}
+	return cr, nil
+}
+
+// IssueCertificate issues a new certificate.
+func (m *PKIManager) IssueCertificate(cr *x509.CertificateRequest) (cert []byte, retErr error) {
+	now := time.Now().UTC()
+	sn, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 160))
+	if err != nil {
+		return nil, err
+	}
+	var eku []x509.ExtKeyUsage
+	if len(cr.DNSNames) > 0 || len(cr.IPAddresses) > 0 {
+		eku = append(eku, x509.ExtKeyUsageServerAuth)
+	} else {
+		eku = append(eku, x509.ExtKeyUsageClientAuth)
+	}
+	templ := &x509.Certificate{
+		Version:               cr.Version,
+		SerialNumber:          sn,
+		PublicKeyAlgorithm:    cr.PublicKeyAlgorithm,
+		PublicKey:             cr.PublicKey,
+		Subject:               cr.Subject,
+		NotBefore:             now,
+		NotAfter:              now.Add(issuedCertsLifetime),
+		KeyUsage:              x509.KeyUsageDataEncipherment | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		ExtKeyUsage:           eku,
+		IssuingCertificateURL: m.opts.IssuingCertificateURL,
+		CRLDistributionPoints: m.opts.CRLDistributionPoints,
+		OCSPServer:            m.opts.OCSPServer,
+		DNSNames:              cr.DNSNames,
+		EmailAddresses:        cr.EmailAddresses,
+		IPAddresses:           cr.IPAddresses,
+		URIs:                  cr.URIs,
+	}
+	return m.signCertificate(templ, nil)
+}
+
+// signCertificate signs a new certificate.
+func (m *PKIManager) signCertificate(cert *x509.Certificate, next func(*certificate) error) (raw []byte, retErr error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	commit, err := m.opts.Store.OpenForUpdate(pkiFile, &m.db)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		commit(false, &retErr)
+		if retErr == storage.ErrRolledBack {
+			retErr = nil
+		}
+	}()
+
+	ca, exists := m.db.CAs[m.opts.Name]
+	if !exists {
+		return nil, errNotFound
+	}
+	caCert, err := ca.CACert.parse()
+	if err != nil {
+		return nil, err
+	}
+	key, err := x509.ParsePKCS8PrivateKey(ca.PrivateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	if raw, err = x509.CreateCertificate(rand.Reader, cert, caCert, cert.PublicKey, key); err != nil {
+		return nil, fmt.Errorf("x509.CreateCertificate: %v", err)
+	}
+
+	h256 := sha256.Sum256(raw)
+	c := &certificate{
+		SHA256:       bytesToHex(h256[:]),
+		SerialNumber: bytesToHex(cert.SerialNumber.Bytes()),
+		Raw:          raw,
+	}
+	ca.IssuedCerts = append(ca.IssuedCerts, c)
+
+	if next != nil {
+		if err := next(c); err != nil {
+			return nil, err
+		}
+	}
+	if err := commit(true, nil); err != nil {
+		return nil, err
+	}
+
+	return raw, nil
+}
+
+func bytesToHex(b []byte) string {
+	h := make([]string, 0, len(b))
+	for _, v := range b {
+		h = append(h, fmt.Sprintf("%02x", v))
+	}
+	return strings.Join(h, ":")
+}

--- a/proxy/internal/pki/pki.go
+++ b/proxy/internal/pki/pki.go
@@ -497,7 +497,7 @@ func (m *PKIManager) IsRevoked(serialNumber *big.Int) bool {
 // OCSPResponse creates an OCSP Response from the given request.
 func (m *PKIManager) OCSPResponse(req *ocsp.Request) ([]byte, error) {
 	if !req.HashAlgorithm.Available() {
-		return nil, errors.New("invalid hash algorithn")
+		return nil, errors.New("invalid hash algorithm")
 	}
 	if err := m.maybeRotateDelegateCert(); err != nil {
 		return nil, err

--- a/proxy/internal/pki/pki.go
+++ b/proxy/internal/pki/pki.go
@@ -295,7 +295,6 @@ func (m *PKIManager) initCA() (retErr error) {
 			SerialNumber: bytesToHex(sn.Bytes()),
 			Raw:          raw,
 		}
-		// Keep most recent first.
 		m.db.CACert = c
 		m.db.IssuedCerts = append(m.db.IssuedCerts, c)
 		changed = true

--- a/proxy/internal/pki/pki_test.go
+++ b/proxy/internal/pki/pki_test.go
@@ -57,17 +57,16 @@ func newPKI(t *testing.T) *PKIManager {
 
 func TestNewPKIManager(t *testing.T) {
 	m := newPKI(t)
-	ca, exists := m.db.CAs["pki-test"]
-	if !exists {
+	if m.db == nil {
 		t.Fatal("pki.example.com doesn't exist")
 	}
-	if ca.CACert == nil {
+	if m.db.CACert == nil {
 		t.Fatal("ca cert is not set")
 	}
-	if _, err := x509.ParseCertificate(ca.CACert.Raw); err != nil {
+	if _, err := x509.ParseCertificate(m.db.CACert.Raw); err != nil {
 		t.Errorf("x509.ParseCertificate: %v", err)
 	}
-	t.Logf("CERT: %s", ca.CACert.pem())
+	t.Logf("CERT: %s", m.db.CACert.pem())
 }
 
 func TestIssueRevoke(t *testing.T) {

--- a/proxy/internal/pki/pki_test.go
+++ b/proxy/internal/pki/pki_test.go
@@ -1,0 +1,172 @@
+// MIT License
+//
+// Copyright (c) 2023 TTBT Enterprises LLC
+// Copyright (c) 2023 Robin Thellend <rthellend@rthellend.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package pki
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"testing"
+
+	"github.com/c2FmZQ/storage"
+	"github.com/c2FmZQ/storage/crypto"
+	"golang.org/x/crypto/ocsp"
+)
+
+func newPKI(t *testing.T) *PKIManager {
+	dir := t.TempDir()
+	mk, err := crypto.CreateAESMasterKeyForTest()
+	if err != nil {
+		t.Fatalf("crypto.CreateMasterKey: %v", err)
+	}
+	opts := Options{
+		Name:     "pki-test",
+		Endpoint: "https://pki.example.com",
+		Store:    storage.New(dir, mk),
+	}
+	m, err := New(opts)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return m
+}
+
+func TestNewPKIManager(t *testing.T) {
+	m := newPKI(t)
+	ca, exists := m.db.CAs["pki-test"]
+	if !exists {
+		t.Fatal("pki.example.com doesn't exist")
+	}
+	if ca.CACert == nil {
+		t.Fatal("ca cert is not set")
+	}
+	if _, err := x509.ParseCertificate(ca.CACert.Raw); err != nil {
+		t.Errorf("x509.ParseCertificate: %v", err)
+	}
+	t.Logf("CERT: %s", ca.CACert.pem())
+}
+
+func TestIssueRevoke(t *testing.T) {
+	m := newPKI(t)
+
+	caCert, err := m.CACert()
+	if err != nil {
+		t.Fatalf("CACert: %v", err)
+	}
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa.GenerateKey: %v", err)
+	}
+	templ := &x509.CertificateRequest{
+		PublicKeyAlgorithm: x509.ECDSA,
+		Subject:            pkix.Name{CommonName: "hello-world"},
+	}
+	raw, err := x509.CreateCertificateRequest(rand.Reader, templ, key)
+	if err != nil {
+		t.Fatalf("x509.CreateCertificateRequest: %v", err)
+	}
+
+	cr, err := m.ValidateCertificateRequest(raw)
+	if err != nil {
+		t.Fatalf("m.ValidateCertificateRequest: %v", err)
+	}
+	certBytes, err := m.IssueCertificate(cr)
+	if err != nil {
+		t.Fatalf("m.IssueCertificate: %v", err)
+	}
+	cert, err := x509.ParseCertificate(certBytes)
+	if err != nil {
+		t.Fatalf("x509.ParseCertificate: %v", err)
+	}
+	if got, want := cert.Subject.String(), "CN=hello-world"; got != want {
+		t.Errorf("Subject) = %v, want %v", got, want)
+	}
+
+	if raw, err = ocsp.CreateRequest(cert, caCert, nil); err != nil {
+		t.Fatalf("ocsp.CreateRequest: %v", err)
+	}
+	ocspReq, err := ocsp.ParseRequest(raw)
+	if err != nil {
+		t.Fatalf("ocsp.ParseRequest: %v", err)
+	}
+	if got, want := m.IsRevoked(cert.SerialNumber), false; got != want {
+		t.Errorf("m.IsRevoked() = %v, want %v", got, want)
+	}
+	if raw, err := m.OCSPResponse(ocspReq); err != nil {
+		t.Errorf("m.OCSPResponse: %v", err)
+	} else if resp, err := ocsp.ParseResponse(raw, caCert); err != nil {
+		t.Errorf("ocsp.ParseResponse: %v", err)
+	} else {
+		t.Logf("OCSP Response: %#v", resp)
+		if got, want := resp.Status, ocsp.Good; got != want {
+			t.Errorf("Response Status = %v, want %v", got, want)
+		}
+	}
+
+	if err := m.RevokeCertificate(cert.SerialNumber, RevokeReasonKeyCompromise); err != nil {
+		t.Fatalf("m.Revoke: %v", err)
+	}
+	if got, want := m.IsRevoked(cert.SerialNumber), true; got != want {
+		t.Errorf("m.IsRevoked() = %v, want %v", got, want)
+	}
+	if raw, err := m.OCSPResponse(ocspReq); err != nil {
+		t.Errorf("m.OCSPResponse: %v", err)
+	} else if resp, err := ocsp.ParseResponse(raw, caCert); err != nil {
+		t.Errorf("ocsp.ParseResponse: %v", err)
+	} else {
+		t.Logf("OCSP Response: %#v", resp)
+		if got, want := resp.Status, ocsp.Revoked; got != want {
+			t.Errorf("Response Status = %v, want %v", got, want)
+		}
+	}
+
+	_, crl, err := m.RevocationList()
+	if err != nil {
+		t.Fatalf("m.RevocationList: %v", err)
+	}
+	_, crl2, err := m.RevocationList()
+	if err != nil {
+		t.Fatalf("m.RevocationList: %v", err)
+	}
+	if !bytes.Equal(crl, crl2) {
+		t.Error("crl not cached")
+	}
+	rl, err := x509.ParseRevocationList(crl)
+	if err != nil {
+		t.Fatalf("x509.ParseRevocationList: %v", err)
+	}
+	if got, want := len(rl.RevokedCertificateEntries), 1; got != want {
+		t.Fatalf("len(RevokedCertificateEntries) = %d, want %d", got, want)
+	}
+	if got, want := rl.RevokedCertificateEntries[0].SerialNumber, cert.SerialNumber; got.Cmp(want) != 0 {
+		t.Errorf("SerialNumber = %s, want %s", got, want)
+	}
+	if got, want := rl.RevokedCertificateEntries[0].ReasonCode, RevokeReasonKeyCompromise; got != want {
+		t.Errorf("ReasonCode = %d, want %d", got, want)
+	}
+}

--- a/proxy/internal/pki/style.css
+++ b/proxy/internal/pki/style.css
@@ -1,0 +1,99 @@
+body {
+  margin: 2rem;
+}
+h1 {
+  font-size: 150%;
+}
+h2 {
+  font-size: 125%;
+}
+#csrform {
+  border: 2px solid black;
+  background-color: slategray;
+  box-shadow: 2px 2px 5px black;
+  color: white;
+  text-align: left;
+  position: fixed;
+  left: 50vw;
+  top: 50vh;
+  transform: translate(-50%, -50%);
+  padding: 1rem;
+  width: clamp(20em, 40em, 90vw);
+  max-height: 80vh;
+  overflow: scroll;
+}
+#viewcert {
+  border: 2px solid black;
+  background-color: slategray;
+  box-shadow: 2px 2px 5px black;
+  color: white;
+  text-align: left;
+  position: fixed;
+  left: 50vw;
+  top: 50vh;
+  transform: translate(-50%, -50%);
+  padding: 1rem;
+  width: clamp(20em, 40em, 90vw);
+  max-height: 80vh;
+  overflow: scroll;
+}
+pre {
+  user-select: all;
+}
+textarea {
+  width: 100%;
+  height: 6rem;
+}
+#filters {
+  margin-top: 3rem;
+}
+.certs {
+  margin-top: 3rem;
+}
+.certs>div {
+  padding: 0.25rem;
+}
+.certs>div:nth-child(odd) {
+  background-color: #444;
+}
+.certs>div:nth-child(even) {
+  background-color: #555;
+}
+.onerow {
+  display: grid;
+  grid-template-columns: 1fr 5fr 1fr;
+  gap: 0;
+}
+.usednow {
+  border: solid 1px yellow;
+}
+.status {
+  justify-self: center;
+  align-self: center;
+}
+.onecert {
+  display: grid;
+  grid-template-columns: 1fr 5fr;
+  gap: 0;
+  line-height: 75%;
+  font-size: 80%;
+}
+.onecert>div {
+  white-space: nowrap;
+  padding: 0.25rem;
+}
+.onecert>div:nth-child(even) {
+  overflow-x: scroll;
+  user-select: all;
+}
+.certButtons {
+  font-size: 80%;
+}
+.table2 {
+  display: grid;
+  grid-template-columns: auto auto;
+  justify-content: start;
+}
+.table2>div {
+  padding: 0.25rem;
+}

--- a/proxy/internal/pki/sw.js
+++ b/proxy/internal/pki/sw.js
@@ -1,0 +1,88 @@
+// MIT License
+//
+// Copyright (c) 2023 TTBT Enterprises LLC
+// Copyright (c) 2023 Robin Thellend <rthellend@thellend.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+'use strict';
+
+self.importScripts('?get=static&file=wasm_exec.js');
+
+self.pkiApp = {};
+self.pkiApp.ready = new Promise(resolve => {
+  pkiApp.pkiwasmIsReady = () => {
+    console.log('PKI WASM is ready');
+    resolve();
+  };
+});
+
+const go = new Go();
+WebAssembly.instantiateStreaming(fetch('?get=static&file=pki.wasm.bz2'), go.importObject)
+  .then(r => go.run(r.instance));
+
+self.addEventListener('activate', event => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'POST') {
+    throw new Error('unexpected method');
+  }
+  event.respondWith(generateKeyAndCert(event.request.body));
+});
+
+let keyCount = 0;
+async function generateKeyAndCert(body) {
+  await self.pkiApp.ready;
+  const count = ++keyCount;
+
+  const reader = body.getReader();
+  const buf = [];
+  while (true) {
+    let {done, value} = await reader.read();
+    if (value) buf.push(...value);
+    if (done) break;
+  }
+  const formdata = new TextDecoder().decode(new Uint8Array(buf));
+
+  console.log('Making CSR');
+  const csr = self.pkiApp.makeCertificateRequest(count, formdata);
+
+  console.log('Fetching Cert');
+  const resp = await fetch('?get=requestCert', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/x-pem-file',
+      'x-csrf-check': '1',
+    },
+    body: csr,
+  });
+  if (resp.status !== 200 || resp.headers.get('content-type') !== 'application/json') {
+    console.log('response is not json', resp);
+    throw new Error('unexpected server response');
+  }
+  const r = await resp.json();
+  if (r.result !== 'ok') {
+    throw new Error('unexpected server response');
+  }
+
+  console.log('Package key and cert');
+  return self.pkiApp.makeResponse(count, r.cert);
+}

--- a/proxy/nopprof.go
+++ b/proxy/nopprof.go
@@ -25,5 +25,5 @@
 
 package proxy
 
-func addPProfHandlers(map[string]localHandler) {
+func addPProfHandlers(*[]localHandler) {
 }

--- a/proxy/pprof.go
+++ b/proxy/pprof.go
@@ -30,16 +30,6 @@ import (
 	"net/http/pprof"
 )
 
-func addPProfHandlers(h map[string]localHandler) {
-	h["/debug/pprof/"] = localHandler{handler: http.HandlerFunc(pprof.Index)}
-	h["/debug/pprof/allocs"] = localHandler{handler: http.HandlerFunc(pprof.Index)}
-	h["/debug/pprof/block"] = localHandler{handler: http.HandlerFunc(pprof.Index)}
-	h["/debug/pprof/goroutine"] = localHandler{handler: http.HandlerFunc(pprof.Index)}
-	h["/debug/pprof/heap"] = localHandler{handler: http.HandlerFunc(pprof.Index)}
-	h["/debug/pprof/mutex"] = localHandler{handler: http.HandlerFunc(pprof.Index)}
-	h["/debug/pprof/threadcreate"] = localHandler{handler: http.HandlerFunc(pprof.Index)}
-	h["/debug/pprof/cmdline"] = localHandler{handler: http.HandlerFunc(pprof.Cmdline)}
-	h["/debug/pprof/profile"] = localHandler{handler: http.HandlerFunc(pprof.Profile)}
-	h["/debug/pprof/symbol"] = localHandler{handler: http.HandlerFunc(pprof.Symbol)}
-	h["/debug/pprof/trace"] = localHandler{handler: http.HandlerFunc(pprof.Trace)}
+func addPProfHandlers(h *[]localHandler) {
+	*h = append(*h, localHandler{path: "/debug/pprof/", matchPrefix: true, handler: http.HandlerFunc(pprof.Index)})
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1170,7 +1170,7 @@ func certSummary(c *x509.Certificate) string {
 	}
 	var parts []string
 	if sub := c.Subject.String(); sub != "" {
-		parts = append(parts, sub)
+		parts = append(parts, "SUBJECT:"+sub)
 	}
 	for _, v := range c.DNSNames {
 		parts = append(parts, "DNS:"+v)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -448,11 +448,11 @@ func TestAuthnAuthz(t *testing.T) {
 		{desc: "ACL, client2", host: "acl.example.com", certName: "client2", want: "HTTP/1.0 200 OK"},
 		{desc: "ACL, wrong cert", host: "acl.example.com", certName: "foo", expError: true},
 		{desc: "PKI client", host: "pkitest.example.com", certName: "pki", want: "HTTP/1.0 200 OK"},
-		{desc: "Check console1", host: "acl.example.com", certName: "client1", want: "allow [CN=client1;DNS:client1] to acl.example.com"},
-		{desc: "Check console2", host: "acl.example.com", certName: "client1", want: "allow [CN=client2;DNS:client2] to acl.example.com"},
-		{desc: "Check console3", host: "acl.example.com", certName: "client1", want: "allow [CN=foo;DNS:foo] to noacl.example.com"},
-		{desc: "Check console4", host: "acl.example.com", certName: "client1", want: "deny [CN=foo;DNS:foo] to acl.example.com"},
-		{desc: "Check console5", host: "acl.example.com", certName: "client1", want: "deny [CN=foo;DNS:foo] to emptyacl.example.com"},
+		{desc: "Check console1", host: "acl.example.com", certName: "client1", want: "allow [SUBJECT:CN=client1;DNS:client1] to acl.example.com"},
+		{desc: "Check console2", host: "acl.example.com", certName: "client1", want: "allow [SUBJECT:CN=client2;DNS:client2] to acl.example.com"},
+		{desc: "Check console3", host: "acl.example.com", certName: "client1", want: "allow [SUBJECT:CN=foo;DNS:foo] to noacl.example.com"},
+		{desc: "Check console4", host: "acl.example.com", certName: "client1", want: "deny [SUBJECT:CN=foo;DNS:foo] to acl.example.com"},
+		{desc: "Check console5", host: "acl.example.com", certName: "client1", want: "deny [SUBJECT:CN=foo;DNS:foo] to emptyacl.example.com"},
 		{desc: "Check console6", host: "acl.example.com", certName: "client1", want: "allow [EMAIL:bob@example.com] to pkitest.example.com"},
 	} {
 		got, err := get(tc.host, tc.certName)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -25,7 +25,10 @@ package proxy
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"io"
@@ -41,6 +44,7 @@ import (
 	"github.com/c2FmZQ/storage/crypto"
 	"github.com/c2FmZQ/tlsproxy/certmanager"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/netw"
+	"github.com/c2FmZQ/tlsproxy/proxy/internal/pki"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/tokenmanager"
 )
 
@@ -63,11 +67,19 @@ func TestProxyBackends(t *testing.T) {
 			TLSAddr:  "localhost:0",
 			CacheDir: t.TempDir(),
 			MaxOpen:  100,
+			PKI: []*ConfigPKI{
+				{Name: "TEST CA"},
+			},
 		},
 		extCA,
 	)
 	if err := proxy.Start(ctx); err != nil {
 		t.Fatalf("proxy.Start: %v", err)
+	}
+
+	pkiCert, err := newPKICert(proxy.pkis["TEST CA"], "tls-pki-internal.example.com")
+	if err != nil {
+		t.Fatalf("newPKICert: %v", err)
 	}
 
 	// Backends without TLS.
@@ -84,9 +96,14 @@ func TestProxyBackends(t *testing.T) {
 	// Backends for HTTP and HTTPS.
 	be8 := newHTTPServer(t, ctx, "backend8", nil)
 	be9 := newHTTPServer(t, ctx, "backend9", intCA)
+	// Backend with PKI cert.
+	be10 := newTCPServer(t, ctx, "backend10", pkiCert)
 
 	cfg := &Config{
-		MaxOpen:           100,
+		MaxOpen: 100,
+		PKI: []*ConfigPKI{
+			{Name: "TEST CA"},
+		},
 		DefaultServerName: "http.example.com",
 		Backends: []*Backend{
 			// Plaintext backends.
@@ -109,7 +126,7 @@ func TestProxyBackends(t *testing.T) {
 					be3.listener.Addr().String(),
 				},
 				Mode:              "TLS",
-				ForwardRootCAs:    intCA.RootCAPEM(),
+				ForwardRootCAs:    []string{intCA.RootCAPEM()},
 				ForwardServerName: "other-internal.example.com",
 			},
 			// TLS backends, require clients to present a certificate.
@@ -121,10 +138,10 @@ func TestProxyBackends(t *testing.T) {
 					be4.listener.Addr().String(),
 				},
 				Mode:              "TLS",
-				ForwardRootCAs:    intCA.RootCAPEM(),
+				ForwardRootCAs:    []string{intCA.RootCAPEM()},
 				ForwardServerName: "secure-internal.example.com",
 				ClientAuth: &ClientAuth{
-					RootCAs: intCA.RootCAPEM(),
+					RootCAs: []string{intCA.RootCAPEM()},
 				},
 			},
 			// TLS backend with imap proto.
@@ -136,7 +153,7 @@ func TestProxyBackends(t *testing.T) {
 					be5.listener.Addr().String(),
 				},
 				Mode:              "TLS",
-				ForwardRootCAs:    intCA.RootCAPEM(),
+				ForwardRootCAs:    []string{intCA.RootCAPEM()},
 				ForwardServerName: "imap-internal.example.com",
 				ALPNProtos:        &[]string{"imap"},
 			},
@@ -149,7 +166,7 @@ func TestProxyBackends(t *testing.T) {
 					be6.listener.Addr().String(),
 				},
 				Mode:              "TLS",
-				ForwardRootCAs:    intCA.RootCAPEM(),
+				ForwardRootCAs:    []string{intCA.RootCAPEM()},
 				ForwardServerName: "noproto-internal.example.com",
 				ALPNProtos:        &[]string{},
 			},
@@ -182,11 +199,26 @@ func TestProxyBackends(t *testing.T) {
 					be9.String(),
 				},
 				Mode:              "HTTPS",
-				ForwardRootCAs:    intCA.RootCAPEM(),
+				ForwardRootCAs:    []string{intCA.RootCAPEM()},
 				ForwardServerName: "https-internal.example.com",
 				ClientAuth: &ClientAuth{
-					RootCAs:             intCA.RootCAPEM(),
+					RootCAs:             []string{intCA.RootCAPEM()},
 					AddClientCertHeader: []string{"cert", "dns", "subject", "hash"},
+				},
+			},
+			// TLS backend w/ PKI
+			{
+				ServerNames: []string{
+					"tls-pki.example.com",
+				},
+				Addresses: []string{
+					be10.listener.Addr().String(),
+				},
+				Mode:              "TLS",
+				ForwardRootCAs:    []string{"TEST CA"},
+				ForwardServerName: "tls-pki-internal.example.com",
+				ClientAuth: &ClientAuth{
+					RootCAs: []string{intCA.RootCAPEM()},
 				},
 			},
 			// HTTPS loop
@@ -198,7 +230,7 @@ func TestProxyBackends(t *testing.T) {
 					proxy.listener.Addr().String(),
 				},
 				Mode:              "HTTPS",
-				ForwardRootCAs:    extCA.RootCAPEM(),
+				ForwardRootCAs:    []string{extCA.RootCAPEM()},
 				ForwardServerName: "loop.example.com",
 			},
 		},
@@ -256,6 +288,7 @@ func TestProxyBackends(t *testing.T) {
 		{desc: "Hit backend7", host: "passthrough.example.com", want: "Hello from backend7\n"},
 		{desc: "Hit backend8", host: "http.example.com", want: "[backend8] /", http: true},
 		{desc: "Hit backend9", host: "https.example.com", want: "[backend9] /", http: true, certName: "client.example.com"},
+		{desc: "Hit backend10", host: "tls-pki.example.com", want: "Hello from backend10\n", certName: "client.example.com"},
 		{desc: "Hit loop", host: "loop.example.com", want: "508 Loop Detected", http: true},
 		{desc: "Hit default backend with IP address as host", host: "", want: "421 Misdirected Request", http: true},
 	} {
@@ -276,6 +309,17 @@ func TestProxyBackends(t *testing.T) {
 			t.Errorf("%s: Got %q, want %q", tc.desc, got, tc.want)
 		}
 	}
+
+	pc, err := x509.ParseCertificate(pkiCert.cert.Certificate[0])
+	if err != nil {
+		t.Fatalf("x509.ParseCertificate: %v", err)
+	}
+	if err := proxy.pkis["TEST CA"].RevokeCertificate(pc.SerialNumber, 0); err != nil {
+		t.Fatalf("RevokeCertificate: %v", err)
+	}
+	if got, err := get("tls-pki.example.com", "client.example.com", nil, false); got != "" {
+		t.Errorf("get with revoked cert should return nothing: %q, %v", got, err)
+	}
 }
 
 func TestAuthnAuthz(t *testing.T) {
@@ -295,6 +339,9 @@ func TestAuthnAuthz(t *testing.T) {
 		TLSAddr:  "localhost:0",
 		CacheDir: t.TempDir(),
 		MaxOpen:  100,
+		PKI: []*ConfigPKI{
+			{Name: "TEST CA"},
+		},
 		Backends: []*Backend{
 			{
 				ServerNames: []string{
@@ -302,7 +349,7 @@ func TestAuthnAuthz(t *testing.T) {
 				},
 				Mode: "CONSOLE",
 				ClientAuth: &ClientAuth{
-					RootCAs: intCA.RootCAPEM(),
+					RootCAs: []string{intCA.RootCAPEM()},
 				},
 			},
 			{
@@ -311,7 +358,7 @@ func TestAuthnAuthz(t *testing.T) {
 				},
 				Mode: "CONSOLE",
 				ClientAuth: &ClientAuth{
-					RootCAs: intCA.RootCAPEM(),
+					RootCAs: []string{intCA.RootCAPEM()},
 					ACL:     &[]string{},
 				},
 			},
@@ -321,10 +368,22 @@ func TestAuthnAuthz(t *testing.T) {
 				},
 				Mode: "CONSOLE",
 				ClientAuth: &ClientAuth{
-					RootCAs: intCA.RootCAPEM(),
+					RootCAs: []string{intCA.RootCAPEM()},
 					ACL: &[]string{
 						"CN=client1",
-						"CN=client2",
+						"DNS:client2",
+					},
+				},
+			},
+			{
+				ServerNames: []string{
+					"pkitest.example.com",
+				},
+				Mode: "CONSOLE",
+				ClientAuth: &ClientAuth{
+					RootCAs: []string{"TEST CA"},
+					ACL: &[]string{
+						"EMAIL:bob@example.com",
 					},
 				},
 			},
@@ -334,9 +393,35 @@ func TestAuthnAuthz(t *testing.T) {
 	if err := proxy.Start(ctx); err != nil {
 		t.Fatalf("proxy.Start: %v", err)
 	}
+	if got, want := len(proxy.pkis), 1; got != want {
+		t.Fatalf("len(pkis) = %d, want %d", got, want)
+	}
+
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+	rawCert, err := proxy.pkis["TEST CA"].IssueCertificate(&x509.CertificateRequest{
+		PublicKey:      &privKey.PublicKey,
+		EmailAddresses: []string{"bob@example.com"},
+	})
+	if err != nil {
+		t.Fatalf("IssueCertificate: %v", err)
+	}
+	pkiCert, err := x509.ParseCertificate(rawCert)
+	if err != nil {
+		t.Fatalf("x509.ParseCertificate: %v", err)
+	}
+	pkiTLSCert := tls.Certificate{
+		Certificate: [][]byte{rawCert},
+		PrivateKey:  privKey,
+	}
+
 	get := func(host, certName string) (string, error) {
 		var certs []tls.Certificate
-		if certName != "" {
+		if certName == "pki" {
+			certs = append(certs, pkiTLSCert)
+		} else if certName != "" {
 			c, err := intCA.GetCert(certName)
 			if err != nil {
 				t.Fatalf("intCA.GetCert: %v", err)
@@ -362,11 +447,13 @@ func TestAuthnAuthz(t *testing.T) {
 		{desc: "ACL, client1", host: "acl.example.com", certName: "client1", want: "HTTP/1.0 200 OK"},
 		{desc: "ACL, client2", host: "acl.example.com", certName: "client2", want: "HTTP/1.0 200 OK"},
 		{desc: "ACL, wrong cert", host: "acl.example.com", certName: "foo", expError: true},
-		{desc: "Check console1", host: "acl.example.com", certName: "client1", want: "allow [CN=client1] to acl.example.com"},
-		{desc: "Check console2", host: "acl.example.com", certName: "client1", want: "allow [CN=client2] to acl.example.com"},
-		{desc: "Check console3", host: "acl.example.com", certName: "client1", want: "allow [CN=foo] to noacl.example.com"},
-		{desc: "Check console4", host: "acl.example.com", certName: "client1", want: "deny [CN=foo] to acl.example.com"},
-		{desc: "Check console5", host: "acl.example.com", certName: "client1", want: "deny [CN=foo] to emptyacl.example.com"},
+		{desc: "PKI client", host: "pkitest.example.com", certName: "pki", want: "HTTP/1.0 200 OK"},
+		{desc: "Check console1", host: "acl.example.com", certName: "client1", want: "allow [CN=client1;DNS:client1] to acl.example.com"},
+		{desc: "Check console2", host: "acl.example.com", certName: "client1", want: "allow [CN=client2;DNS:client2] to acl.example.com"},
+		{desc: "Check console3", host: "acl.example.com", certName: "client1", want: "allow [CN=foo;DNS:foo] to noacl.example.com"},
+		{desc: "Check console4", host: "acl.example.com", certName: "client1", want: "deny [CN=foo;DNS:foo] to acl.example.com"},
+		{desc: "Check console5", host: "acl.example.com", certName: "client1", want: "deny [CN=foo;DNS:foo] to emptyacl.example.com"},
+		{desc: "Check console6", host: "acl.example.com", certName: "client1", want: "allow [EMAIL:bob@example.com] to pkitest.example.com"},
 	} {
 		got, err := get(tc.host, tc.certName)
 		if tc.expError != (err != nil) {
@@ -379,6 +466,13 @@ func TestAuthnAuthz(t *testing.T) {
 		if !strings.Contains(got, tc.want) {
 			t.Errorf("%s: Got %q, want %q", tc.desc, got, tc.want)
 		}
+	}
+
+	if err := proxy.pkis["TEST CA"].RevokeCertificate(pkiCert.SerialNumber, 0); err != nil {
+		t.Fatalf("RevokeCertificate: %v", err)
+	}
+	if _, err := get("pkitest.example.com", "pki"); err == nil {
+		t.Error("get with revoked cert should have failed")
 	}
 }
 
@@ -422,7 +516,7 @@ func TestConcurrency(t *testing.T) {
 						be2.String(),
 					},
 					ForwardRateLimit:  1000,
-					ForwardRootCAs:    ca.RootCAPEM(),
+					ForwardRootCAs:    []string{ca.RootCAPEM()},
 					ForwardServerName: "https-server",
 				},
 				{
@@ -446,7 +540,7 @@ func TestConcurrency(t *testing.T) {
 						be4.String(),
 					},
 					ForwardRateLimit:  1000,
-					ForwardRootCAs:    ca.RootCAPEM(),
+					ForwardRootCAs:    []string{ca.RootCAPEM()},
 					ForwardServerName: "tls-server",
 				},
 				{
@@ -688,7 +782,11 @@ func newHTTPServer(t *testing.T, ctx context.Context, name string, ca *certmanag
 	return l.Addr()
 }
 
-func newTCPServer(t *testing.T, ctx context.Context, name string, ca *certmanager.CertManager) *tcpServer {
+type tcProvider interface {
+	TLSConfig() *tls.Config
+}
+
+func newTCPServer(t *testing.T, ctx context.Context, name string, ca tcProvider) *tcpServer {
 	var l net.Listener
 	var err error
 	if ca == nil {
@@ -729,4 +827,35 @@ func newTCPServer(t *testing.T, ctx context.Context, name string, ca *certmanage
 type tcpServer struct {
 	t        *testing.T
 	listener net.Listener
+}
+
+type pkiCert struct {
+	cert tls.Certificate
+}
+
+func newPKICert(m *pki.PKIManager, name string) (*pkiCert, error) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+	rawCert, err := m.IssueCertificate(&x509.CertificateRequest{
+		PublicKey: &privKey.PublicKey,
+		DNSNames:  []string{name},
+	})
+	if err != nil {
+		return nil, err
+	}
+	c := &pkiCert{
+		cert: tls.Certificate{
+			Certificate: [][]byte{rawCert},
+			PrivateKey:  privKey,
+		},
+	}
+	return c, nil
+}
+
+func (c *pkiCert) TLSConfig() *tls.Config {
+	return &tls.Config{
+		Certificates: []tls.Certificate{c.cert},
+	}
 }

--- a/proxy/sso_test.go
+++ b/proxy/sso_test.go
@@ -91,7 +91,7 @@ func TestSSOEnforceOIDC(t *testing.T) {
 					},
 					ForwardServerName: "https-server",
 					ForwardRateLimit:  1000,
-					ForwardRootCAs:    ca.RootCAPEM(),
+					ForwardRootCAs:    []string{ca.RootCAPEM()},
 					SSO: &BackendSSO{
 						Provider:         "test-idp",
 						GenerateIDTokens: true,
@@ -243,7 +243,7 @@ func TestSSOEnforcePasskey(t *testing.T) {
 					},
 					ForwardServerName: "https-server",
 					ForwardRateLimit:  1000,
-					ForwardRootCAs:    ca.RootCAPEM(),
+					ForwardRootCAs:    []string{ca.RootCAPEM()},
 					SSO: &BackendSSO{
 						Provider: "test-passkey",
 					},
@@ -305,6 +305,7 @@ func TestSSOEnforcePasskey(t *testing.T) {
 		if hdr == nil {
 			hdr = make(http.Header)
 		}
+		hdr.Set("x-csrf-check", "1")
 		req.Header = hdr
 		resp, err := client.Do(req)
 		if err != nil {
@@ -335,7 +336,7 @@ func TestSSOEnforcePasskey(t *testing.T) {
 	if got, want := code, 200; got != want {
 		t.Errorf("Code = %v, want %v", got, want)
 	}
-	if haystack, needle := body, "registerPasskey(&#34;https://https.example.com/blah&#34;);"; !strings.Contains(haystack, needle) {
+	if haystack, needle := body, "registerPasskey(&#34;https://https.example.com/blah&#34;"; !strings.Contains(haystack, needle) {
 		t.Errorf("Body = %v, want %v", haystack, needle)
 	}
 
@@ -346,7 +347,7 @@ func TestSSOEnforcePasskey(t *testing.T) {
 	auth.SetOrigin("https://" + host)
 
 	// Get the attestation options.
-	code, body, _ = get("https://"+host+"/passkey?get=AttestationOptions", nil, nil)
+	code, body, _ = get("https://"+host+"/passkey?get=AttestationOptions", nil, []byte{})
 	if got, want := code, 200; got != want {
 		t.Errorf("Code = %v, want %v", got, want)
 	}
@@ -402,12 +403,12 @@ func TestSSOEnforcePasskey(t *testing.T) {
 	if got, want := code, 200; got != want {
 		t.Errorf("Code = %v, want %v", got, want)
 	}
-	if haystack, needle := body, "loginWithPasskey(&#34;https://https.example.com/blah&#34;);"; !strings.Contains(haystack, needle) {
+	if haystack, needle := body, "loginWithPasskey(&#34;https://https.example.com/blah&#34;"; !strings.Contains(haystack, needle) {
 		t.Errorf("Body = %v, want %v", haystack, needle)
 	}
 
 	// Get the assertion options.
-	code, body, _ = get("https://"+host+"/passkey?get=AssertionOptions", nil, nil)
+	code, body, _ = get("https://"+host+"/passkey?get=AssertionOptions", nil, []byte{})
 	if got, want := code, 200; got != want {
 		t.Errorf("Code = %v, want %v", got, want)
 	}

--- a/proxy/style.css
+++ b/proxy/style.css
@@ -12,7 +12,7 @@ body {
 #buttons {
   position: fixed;
   top: 10px;
-  right: 10px;
+  right: 2rem;
 }
 a {
   color: white;
@@ -21,12 +21,12 @@ a {
 a.button {
   text-decoration: none;
   border: solid 1px black;
-  border-radius: 1em;
+  border-radius: 1rem;
   background-color: lightgray;
   color: black;
-  margin: 1em;
-  padding: 0.5em;
-  line-height: 3em;
+  margin: 0;
+  padding: 0.25rem;
+  line-height: 1.5rem;
   white-space: nowrap;
 }
 a.button:hover {
@@ -39,9 +39,9 @@ a.button:hover {
   left: 50vw;
   top: 50vh;
   transform: translate(-50%, -50%);
-  padding: 1em;
+  padding: 1rem;
   background-color: black;
-  width: clamp(20em, 40em, 90vw);
+  width: clamp(20rem, 40rem, 90vw);
   max-height: 80vh;
   overflow: scroll;
 }


### PR DESCRIPTION
### Description

This change adds new PKI functionality to TLSPROXY. Users can issue and revoke their own certificates, which can be used for TLS client or server authentication on TLSPROXY or other TLS-enabled applications.

TLSPROXY supports OCSP and can publish CRLs.

This change also includes some improvements to passkeys and authentication in general, e.g. forceReAuth, and TLS access control based on SAN EMAIL.

### Type of change

* [x] New feature
* [x] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)


### How is this change tested ?

* [x] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
