### PR TITLE
Add support for github oauth2

### DIFF
--- a/examples/sso/README.md
+++ b/examples/sso/README.md
@@ -2,7 +2,8 @@
 
 TLSPROXY can be configured to authenticate users with OpenID Connect and SAML identity providers. Another option is to use Passkeys for password-less user authentication. To configure Passkeys, users still need to authenticate once with OpenID Connect or SAML, but then authentication is done exclusively with Passkeys.
 
-OpenID Connect has been tested with Google and Facebook as identity providers.
+OpenID Connect has been tested with Google, Facebook, and GitHub as identity providers.
+
 SAML has been tested with Google Workspace.
 
 ## Google OpenID Connect
@@ -63,6 +64,43 @@ backends:
   - 192.168.1.1:80
   sso:
     provider: facebook
+    acl:
+      - alice@EXAMPLE.COM
+      - bob@EXAMPLE.COM
+      - "@EXAMPLE.COM"   <--- allows anyone from EXAMPLE.COM
+```
+
+## GitHub OAuth2
+
+GitHub doesn't implement OpenID Connect, but their OAuth2 workflow can be used with TLSPROXY to retrieve the user's identity.
+
+https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps
+
+```yaml
+oidc:
+- name: github
+  authorizationEndpoint: "https://github.com/login/oauth/authorize"
+  tokenEndpoint: "https://github.com/login/oauth/access_token"
+  userinfoEndpoint: "https://api.github.com/user"
+  scopes:
+  - "user:email"
+  redirectUrl: "https://login.EXAMPLE.COM/oauth2/github"
+  clientId: "<YOUR CLIENT ID>"
+  clientSecret: "<YOUR CLIENT SECRET>"
+  domain: EXAMPLE.COM
+
+backends:
+- serverNames:
+  - login.EXAMPLE.COM
+  mode: https
+
+- serverNames:
+  - www.EXAMPLE.COM
+  mode: http
+  addresses:
+  - 192.168.1.1:80
+  sso:
+    provider: github
     acl:
       - alice@EXAMPLE.COM
       - bob@EXAMPLE.COM

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -315,6 +315,10 @@ type ConfigOIDC struct {
 	// TokenEndpoint is the token endpoint. It must be set only if
 	// DiscoveryURL is not set.
 	TokenEndpoint string `yaml:"tokenEndpoint,omitempty"`
+	// UserinfoEndpoint is the userinfo endpoint. It must be set only if
+	// DiscoveryURL is not set and the token endpoint doesn't return an
+	// ID token.
+	UserinfoEndpoint string `yaml:"userinfoEndpoint,omitempty"`
 	// RedirectURL is the OAUTH2 redirect URL. It must be managed by the
 	// proxy.
 	RedirectURL string `yaml:"redirectUrl"`

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -251,13 +251,14 @@ func (p *Proxy) Reconfigure(cfg *Config) error {
 		issuer := "https://" + host + "/"
 		cm := cookiemanager.New(p.tokenManager, pp.Name, pp.Domain, issuer)
 		oidcCfg := oidc.Config{
-			DiscoveryURL:  pp.DiscoveryURL,
-			AuthEndpoint:  pp.AuthEndpoint,
-			Scopes:        pp.Scopes,
-			TokenEndpoint: pp.TokenEndpoint,
-			RedirectURL:   pp.RedirectURL,
-			ClientID:      pp.ClientID,
-			ClientSecret:  pp.ClientSecret,
+			DiscoveryURL:     pp.DiscoveryURL,
+			AuthEndpoint:     pp.AuthEndpoint,
+			Scopes:           pp.Scopes,
+			TokenEndpoint:    pp.TokenEndpoint,
+			UserinfoEndpoint: pp.UserinfoEndpoint,
+			RedirectURL:      pp.RedirectURL,
+			ClientID:         pp.ClientID,
+			ClientSecret:     pp.ClientSecret,
 		}
 		provider, err := oidc.New(oidcCfg, er, cm)
 		if err != nil {


### PR DESCRIPTION
### Description

Add support for using GitHub as Identity Provider for SSO.

GitHub doesn't implement OpenID Connect, but their OAuth2 workflow can be used with TLSPROXY to retrieve the user's identity. https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps

### Type of change

* [x] New feature
* [ ] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)

### How is this change tested ?

* [ ] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed

Tested manually with a test github oauth app.