### PR TITLE
Keep original `sub` claim, use `email` for auth

### DIFF
--- a/examples/sso/README.md
+++ b/examples/sso/README.md
@@ -2,7 +2,7 @@
 
 TLSPROXY can be configured to authenticate users with OpenID Connect and SAML identity providers. Another option is to use Passkeys for password-less user authentication. To configure Passkeys, users still need to authenticate once with OpenID Connect or SAML, but then authentication is done exclusively with Passkeys.
 
-OpenID Connect has been tested with Google, Facebook, and GitHub as identity providers.
+OpenID Connect has been tested with Google, Facebook, SimpleLogin, and GitHub as identity providers.
 
 SAML has been tested with Google Workspace.
 
@@ -64,6 +64,38 @@ backends:
   - 192.168.1.1:80
   sso:
     provider: facebook
+    acl:
+      - alice@EXAMPLE.COM
+      - bob@EXAMPLE.COM
+      - "@EXAMPLE.COM"   <--- allows anyone from EXAMPLE.COM
+```
+
+## SimpleLogin OpenID Connect (SIWSL)
+
+https://simplelogin.io/docs/siwsl/app/
+
+```yaml
+oidc:
+- name: siwsl
+  authorizationEndpoint: "https://app.simplelogin.io/oauth2/authorize"
+  tokenEndpoint: "https://app.simplelogin.io/oauth2/token"
+  redirectUrl: "https://login.EXAMPLE.COM/oidc/siwsl"
+  clientId: "<YOUR APP ID>"
+  clientSecret: "<YOUR APP SECRET>"
+  domain: EXAMPLE.COM
+
+backends:
+- serverNames:
+  - login.EXAMPLE.COM
+  mode: https
+
+- serverNames:
+  - www.EXAMPLE.COM
+  mode: http
+  addresses:
+  - 192.168.1.1:80
+  sso:
+    provider: siwsl
     acl:
       - alice@EXAMPLE.COM
       - bob@EXAMPLE.COM

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -288,10 +288,13 @@ type Backend struct {
 }
 
 type localHandler struct {
+	desc        string
+	host        string
 	path        string
 	handler     http.Handler
 	ssoBypass   bool
 	matchPrefix bool
+	isCallback  bool
 }
 
 // ClientAuth specifies how to authenticate and authorize the TLS client's

--- a/proxy/internal/cookiemanager/cookiemanager_test.go
+++ b/proxy/internal/cookiemanager/cookiemanager_test.go
@@ -50,7 +50,7 @@ func TestCookies(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 
-	if err := cm.SetAuthTokenCookie(recorder, "test@example.com", "session123", "example.com", nil); err != nil {
+	if err := cm.SetAuthTokenCookie(recorder, "test@example.com", "test@example.com", "session123", "example.com", nil); err != nil {
 		t.Fatalf("SetAuthTokenCookie: %v", err)
 	}
 

--- a/proxy/internal/oidc/server.go
+++ b/proxy/internal/oidc/server.go
@@ -276,7 +276,7 @@ func (s *ProviderServer) ServeAuthorization(w http.ResponseWriter, req *http.Req
 	sc := "openid"
 	scopes := strings.Split(req.Form.Get("scope"), " ")
 	if slices.Contains(scopes, "email") {
-		claims["email"] = claims["sub"]
+		claims["email"] = userClaims["email"]
 		claims["email_verified"] = true
 		sc += " email"
 	}

--- a/proxy/internal/passkeys/auth-template.html
+++ b/proxy/internal/passkeys/auth-template.html
@@ -33,7 +33,7 @@
     <div><a class="button big" onclick="loginWithPasskey({{.RedirectURL}},{{.Nonce}});">Login</a></div>
 {{- end }}
 {{- if eq .Mode "RegisterNewID" }}
-    <div>{{.Subject}}</div>
+    <div>{{.Email}}</div>
   {{- if .IsAllowed }}
     {{- if .IsRegistered }}
     <div>Already Registered</div>

--- a/proxy/internal/passkeys/manage-template.html
+++ b/proxy/internal/passkeys/manage-template.html
@@ -31,7 +31,7 @@
 </head>
 <body>
   <div id="subject">
-  {{ .Subject }}
+  {{ .Email }}
   </div>
   <div id="buttons">
     <a class="button" onclick="registerPasskey();">Register New Passkey</a>

--- a/proxy/internal/pki/certs.html
+++ b/proxy/internal/pki/certs.html
@@ -12,7 +12,7 @@
 <div id="buttons">
   <a class="button" onclick="showForm();">New Cert</a>
 </div>
-<div id="identity">{{$.Subject}}</div>
+<div id="identity">{{$.Email}}</div>
 
 <div class="certs">Certificate Authority:
 <div class="onecert">

--- a/proxy/internal/saml/saml.go
+++ b/proxy/internal/saml/saml.go
@@ -48,7 +48,7 @@ import (
 // http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf
 
 type CookieManager interface {
-	SetAuthTokenCookie(w http.ResponseWriter, userID, sessionID, host string, extraClaims map[string]any) error
+	SetAuthTokenCookie(w http.ResponseWriter, userID, email, sessionID, host string, extraClaims map[string]any) error
 	ClearCookies(w http.ResponseWriter) error
 }
 
@@ -251,7 +251,7 @@ func (p *Provider) HandleCallback(w http.ResponseWriter, req *http.Request) {
 		// Value: Bob
 		extraClaims[key] = value
 	}
-	if err := p.cm.SetAuthTokenCookie(w, sub, id, state.Host, extraClaims); err != nil {
+	if err := p.cm.SetAuthTokenCookie(w, sub, sub, id, state.Host, extraClaims); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/proxy/permission-denied-template.html
+++ b/proxy/permission-denied-template.html
@@ -21,7 +21,7 @@
 </div>
 <div id="message">
 <div class="big">🛂</div>
-<div><em>{{.Subject}}</em> is not permitted to access</div>
+<div><em>{{.Email}}</em> is not permitted to access</div>
 <div id="target"><a href="{{.URL}}">{{.DisplayURL}}</a></div>
 </div>
 </div>

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -450,12 +450,12 @@ func TestAuthnAuthz(t *testing.T) {
 		{desc: "ACL, client2", host: "acl.example.com", certName: "client2", want: "HTTP/1.0 200 OK"},
 		{desc: "ACL, wrong cert", host: "acl.example.com", certName: "foo", expError: true},
 		{desc: "PKI client", host: "pkitest.example.com", certName: "pki", want: "HTTP/1.0 200 OK"},
-		{desc: "Check console1", host: "acl.example.com", certName: "client1", want: "allow [SUBJECT:CN=client1;DNS:client1] to acl.example.com"},
-		{desc: "Check console2", host: "acl.example.com", certName: "client1", want: "allow [SUBJECT:CN=client2;DNS:client2] to acl.example.com"},
-		{desc: "Check console3", host: "acl.example.com", certName: "client1", want: "allow [SUBJECT:CN=foo;DNS:foo] to noacl.example.com"},
-		{desc: "Check console4", host: "acl.example.com", certName: "client1", want: "deny [SUBJECT:CN=foo;DNS:foo] to acl.example.com"},
-		{desc: "Check console5", host: "acl.example.com", certName: "client1", want: "deny [SUBJECT:CN=foo;DNS:foo] to emptyacl.example.com"},
-		{desc: "Check console6", host: "acl.example.com", certName: "client1", want: "allow [EMAIL:bob@example.com] to pkitest.example.com"},
+		{desc: "Check console1", host: "acl.example.com", certName: "client1", want: "allow X509 [SUBJECT:CN=client1;DNS:client1] to acl.example.com"},
+		{desc: "Check console2", host: "acl.example.com", certName: "client1", want: "allow X509 [SUBJECT:CN=client2;DNS:client2] to acl.example.com"},
+		{desc: "Check console3", host: "acl.example.com", certName: "client1", want: "allow X509 [SUBJECT:CN=foo;DNS:foo] to noacl.example.com"},
+		{desc: "Check console4", host: "acl.example.com", certName: "client1", want: "deny X509 [SUBJECT:CN=foo;DNS:foo] to acl.example.com"},
+		{desc: "Check console5", host: "acl.example.com", certName: "client1", want: "deny X509 [SUBJECT:CN=foo;DNS:foo] to emptyacl.example.com"},
+		{desc: "Check console6", host: "acl.example.com", certName: "client1", want: "allow X509 [EMAIL:bob@example.com] to pkitest.example.com"},
 	} {
 		got, err := get(tc.host, tc.certName)
 		if tc.expError != (err != nil) {

--- a/proxy/sso_test.go
+++ b/proxy/sso_test.go
@@ -488,7 +488,8 @@ func newIDPServer(t *testing.T) *idpServer {
 		Issuer:       "https://idp.example.com",
 		ClaimsFromCtx: func(context.Context) jwt.MapClaims {
 			return jwt.MapClaims{
-				"sub": "bob@example.com",
+				"email": "bob@example.com",
+				"sub":   "bob.example.com",
 			}
 		},
 		Clients: []oidc.Client{


### PR DESCRIPTION
### Description

Keep the subject claim from the identity provider as a unique identifier in case email isn't good enough. Unfortunately, this require deleting any existing passkeys that were already saved.

Add more data to console.

Add an example for SSO with SimpleLogin OIDC (SIWSL).

Some minor bug fixes.

### Type of change

* [ ] New feature
* [x] Feature improvement
* [x] Bug fix
* [ ] Documentation
* [x] Cleanup / refactoring
* [ ] Other (please explain)


### How is this change tested ?

* [x] Unit tests
* [ ] Manual tests (explain)
* [ ] Tests are not needed
