### PR TITLE
Route connection using ALPN proto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # TLSPROXY Release Notes
 
+## next
+
+* Allow multiple backends with the same server name but different ALPN protos, e.g. one backend could have foo.example.com with the default ALPN protos, and another backend could have foo.example.com with `alpnProtos: [imap]`. If ALPN is not used by the client, the first backend with a matching server name will be used.
+
 ## v0.1.0
 
 Let's call this the first _stable_ development release. We'll try to keep decent release notes going forward.

--- a/proxy/config_test.go
+++ b/proxy/config_test.go
@@ -100,6 +100,7 @@ func TestReadConfig(t *testing.T) {
 				},
 				ForwardRateLimit: 5,
 				Mode:             "TLS",
+				ALPNProtos:       &[]string{"h2", "http/1.1"},
 				ClientAuth: &ClientAuth{
 					RootCAs: []string{demoCert},
 				},
@@ -116,6 +117,7 @@ func TestReadConfig(t *testing.T) {
 				},
 				ForwardRateLimit: 5,
 				Mode:             "TCP",
+				ALPNProtos:       &[]string{"h2", "http/1.1"},
 				ClientAuth: &ClientAuth{
 					RootCAs: []string{demoCert},
 				},
@@ -130,6 +132,7 @@ func TestReadConfig(t *testing.T) {
 				},
 				ForwardRateLimit: 5,
 				Mode:             "TLSPASSTHROUGH",
+				ALPNProtos:       &[]string{"h2", "http/1.1"},
 				ForwardTimeout:   30 * time.Second,
 			},
 		},

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -149,7 +149,7 @@ func TestProxyBackends(t *testing.T) {
 			// TLS backend with imap proto.
 			{
 				ServerNames: []string{
-					"imap.example.com",
+					"secure.example.com",
 				},
 				Addresses: []string{
 					be5.listener.Addr().String(),
@@ -281,9 +281,8 @@ func TestProxyBackends(t *testing.T) {
 		{desc: "Hit backend4", host: "secure.example.com", want: "Hello from backend4\n", certName: "client.example.com"},
 		{desc: "Hit backend4 no cert", host: "secure.example.com", expError: true},
 		{desc: "Hit backend4 bad proto", host: "secure.example.com", certName: "client.example.com", protos: []string{"ftp"}, expError: true},
-		{desc: "Hit backend5", host: "imap.example.com", want: "Hello from backend5\n"},
-		{desc: "Hit backend5 proto:imap", host: "imap.example.com", want: "Hello from backend5\n", protos: []string{"imap"}},
-		{desc: "Hit backend5 proto:h2", host: "imap.example.com", protos: []string{"h2"}, expError: true},
+		{desc: "Hit backend5 proto:imap", host: "secure.example.com", want: "Hello from backend5\n", protos: []string{"imap"}},
+		{desc: "Hit backend5 proto:h2", host: "secure.example.com", protos: []string{"ftp"}, expError: true},
 		{desc: "Hit backend6", host: "noproto.example.com", want: "Hello from backend6\n"},
 		{desc: "Hit backend6 random proto", host: "noproto.example.com", want: "Hello from backend6\n", protos: []string{"foo", "bar"}},
 		{desc: "Unknown server name", host: "foo.example.com", expError: true},


### PR DESCRIPTION
### Description

Allow multiple backends with the same server name but different ALPN protos, e.g. one backend could have foo.example.com with the default ALPN protos, and another backend could have foo.example.com with `alpnProtos: [imap]`.

### Type of change

* [ ] New feature
* [x] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)


### How is this change tested ?

* [x] Unit tests
* [ ] Manual tests (explain)
* [ ] Tests are not needed
