### PR TITLE
Add routing by HTTP path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## next
 
 * Add support for the HTTP/2 protocol in reverse proxy mode. This only works when the backend actually supports HTTP/2. So, it is not enabled by default. To enable it, set `alpnProtos: [h2, http/1.1]` on the backend explicitly.
+* Add support for routing HTTP requests based on path. By default, all requests go to the same backend servers. When `pathOverrides` is set, some paths can be routed to other servers.
 
 ## v0.1.1
 


### PR DESCRIPTION
### Description

Add support for routing requests based on the HTTP path. By default, all requests go to the same backend servers. When `pathOverrides` is set, some paths can be routed to other servers, e.g.

```yaml
backends:
- serverNames: [example.com]
  mode: http
  addresses: [192.168.0.1:80]
  pathOverrides:
  - paths: [/foo,/bar]
    addresses: [192.168.0.2:80]
  - paths: [/foobar]
    addresses: [192.168.0.3:80]
```

https://github.com/c2FmZQ/tlsproxy/issues/30

### Type of change

* [x] New feature
* [ ] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)


### How is this change tested ?

* [x] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
