### PR TITLE
Decouple the client and backend protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## next
 
-* Decouple frontend and backend protocols in reverse-proxy modes.
+* Decouple frontend and backend protocols in `mode: http` and `mode: https`. The ALPN protocols that TLSPROXY accepts are specified in `alpnProtos: [...]`, and the protocol to use with the request to the backend is specified with `backendProto: ...`, which defaults to `http/1.1`. The previous behavior was to use the same protocol that the client used. It is still possible to do that by setting `backendProto` explicitly to an empty string.
 * Fix QUIC stream direction in metrics.
 
 ## v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## next
 
-* Fix QUIC stream direction in metrics
+* Decouple frontend and backend protocols in reverse-proxy modes.
+* Fix QUIC stream direction in metrics.
 
 ## v0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Decouple frontend and backend protocols in `mode: http` and `mode: https`. The ALPN protocols that TLSPROXY accepts are specified in `alpnProtos: [...]`, and the protocol to use with the request to the backend is specified with `backendProto: ...`, which defaults to `http/1.1`. The previous behavior was to use the same protocol that the client used. It is still possible to do that by setting `backendProto` explicitly to an empty string.
 * Fix QUIC stream direction in metrics.
+* Fix persistent config reload every 30 sec in some conditions.
 
 ## v0.3.0
 

--- a/examples/backend/backend.go
+++ b/examples/backend/backend.go
@@ -241,7 +241,8 @@ func (s *service) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		fmt.Fprintln(w, "</pre>")
 	}
 
-	fmt.Fprintf(w, "%s<br>\n", req.Proto)
+	fmt.Fprintf(w, "Proto: %s<br>\n", req.Proto)
+	fmt.Fprintf(w, "Via: %s\n", html.EscapeString(req.Header.Get("via")))
 }
 
 func audienceFromReq(req *http.Request) string {

--- a/proxy/backend.go
+++ b/proxy/backend.go
@@ -515,7 +515,7 @@ func (be *Backend) reverseProxyModifyResponse(resp *http.Response) error {
 	if resp.StatusCode != http.StatusMisdirectedRequest && resp.Header.Get(hstsHeader) == "" {
 		resp.Header.Set(hstsHeader, hstsValue)
 	}
-	if resp.StatusCode == http.StatusOK && resp.Header.Get("Alt-Svc") == "" {
+	if resp.StatusCode >= 200 && resp.StatusCode < 400 && resp.Header.Get("Alt-Svc") == "" {
 		be.setAltSvc(resp.Header, req)
 	}
 	return nil

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -190,6 +190,12 @@ type Backend struct {
 	//
 	// https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids
 	ALPNProtos *[]string `yaml:"alpnProtos,omitempty"`
+	// BackendProto specifies which protocol to use when forwarding an HTTPS
+	// request to the backend. This field is only valid in modes HTTP and
+	// HTTPS. If unspecified, the same protocol used by the client will be
+	// used with the backend.
+	// The value should be an ALPN protocol, e.g.: http/1.1, h2, or h3.
+	BackendProto string `yaml:"backendProto,omitempty"`
 	// Mode controls how the proxy communicates with the backend.
 	// - PLAINTEXT: Use a plaintext, non-encrypted, TCP connection. This is
 	//     the default mode.
@@ -505,6 +511,12 @@ type PathOverride struct {
 	Addresses []string `yaml:"addresses,omitempty"`
 	// Mode is either HTTP or HTTPS.
 	Mode string `yaml:"mode"`
+	// BackendProto specifies which protocol to use when forwarding an HTTPS
+	// request to the backend. This field is only valid in modes HTTP and
+	// HTTPS. If unspecified, the same protocol used by the client will be
+	// used with the backend.
+	// The value should be an ALPN protocol, e.g.: http/1.1, h2, or h3.
+	BackendProto string `yaml:"backendProto,omitempty"`
 	// InsecureSkipVerify disabled the verification of the backend server's
 	// TLS certificate. See https://pkg.go.dev/crypto/tls#Config
 	InsecureSkipVerify bool `yaml:"insecureSkipVerify,omitempty"`

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -178,13 +178,9 @@ type Backend struct {
 	// ALPNProtos specifies the list of ALPN procotols supported by this
 	// backend. The ACME acme-tls/1 protocol doesn't need to be specified.
 	//
-	// The default values are:
-	//   [http/1.1] for HTTP and HTTPS modes, and
-	//   [h2, http/1.1] for all the other modes.
+	// The default values are: [h2, http/1.1]
 	//
-	// To enable HTTP/2 in HTTPS mode, set the value to [h2, http/1.1]
-	// explicitly. Only do this if the backend server supports HTTP/2.
-	//
+	// Set the value to [h3, h2, http/1.1] to enable HTTP/3.
 	// Set the value to an empty slice [] to disable ALPN.
 	// The negotiated protocol is forwarded to the backends that use TLS.
 	//
@@ -192,13 +188,14 @@ type Backend struct {
 	ALPNProtos *[]string `yaml:"alpnProtos,omitempty"`
 	// BackendProto specifies which protocol to use when forwarding an HTTPS
 	// request to the backend. This field is only valid in modes HTTP and
-	// HTTPS. If unspecified, the same protocol used by the client will be
-	// used with the backend.
-	// The value should be an ALPN protocol, e.g.: http/1.1, h2, or h3.
-	BackendProto string `yaml:"backendProto,omitempty"`
+	// HTTPS.
+	// The value should be an ALPN protocol, e.g.: http/1.1, h2, or h3. The default is http/1.1.
+	// If the value is set explicitly to "", the same protocol used by the
+	//  client will be used with the backend.
+	BackendProto *string `yaml:"backendProto,omitempty"`
 	// Mode controls how the proxy communicates with the backend.
 	// - PLAINTEXT: Use a plaintext, non-encrypted, TCP connection. This is
-	//     the default mode.
+	// the the default mode.
 	//        CLIENT --TLS--> PROXY ----> BACKEND SERVER
 	// - TLS: Open a new TLS connection. Set ForwardServerName, ForwardRootCAs,
 	//     and/or InsecureSkipVerify to verify the identity of the server.
@@ -513,10 +510,11 @@ type PathOverride struct {
 	Mode string `yaml:"mode"`
 	// BackendProto specifies which protocol to use when forwarding an HTTPS
 	// request to the backend. This field is only valid in modes HTTP and
-	// HTTPS. If unspecified, the same protocol used by the client will be
-	// used with the backend.
+	// HTTPS.
 	// The value should be an ALPN protocol, e.g.: http/1.1, h2, or h3.
-	BackendProto string `yaml:"backendProto,omitempty"`
+	// If the value is set explicitly to "", the same protocol used by the
+	//  client will be used with the backend.
+	BackendProto *string `yaml:"backendProto,omitempty"`
 	// InsecureSkipVerify disabled the verification of the backend server's
 	// TLS certificate. See https://pkg.go.dev/crypto/tls#Config
 	InsecureSkipVerify bool `yaml:"insecureSkipVerify,omitempty"`
@@ -744,11 +742,7 @@ func (cfg *Config) Check() error {
 			return fmt.Errorf("backend[%d].ClientAuth: client auth is not compatible with TLS Passthrough", i)
 		}
 		if be.ALPNProtos == nil {
-			if be.Mode == ModeHTTP || be.Mode == ModeHTTPS {
-				be.ALPNProtos = &[]string{"http/1.1"}
-			} else {
-				be.ALPNProtos = defaultALPNProtos
-			}
+			be.ALPNProtos = defaultALPNProtos
 		}
 		if be.Mode == ModeQUIC {
 			var falsex bool

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -744,6 +744,9 @@ func (cfg *Config) Check() error {
 		if be.ALPNProtos == nil {
 			be.ALPNProtos = defaultALPNProtos
 		}
+		if be.BackendProto != nil && be.Mode != ModeHTTP && be.Mode != ModeHTTPS {
+			return fmt.Errorf("backend[%d].BackendProto: field is not valid in mode %s", i, be.Mode)
+		}
 		if be.Mode == ModeQUIC {
 			var falsex bool
 			if be.ServerCloseEndsConnection == nil {

--- a/proxy/config_test.go
+++ b/proxy/config_test.go
@@ -75,7 +75,7 @@ func TestReadConfig(t *testing.T) {
 				},
 				ForwardRateLimit: 5,
 				Mode:             "HTTP",
-				ALPNProtos:       &[]string{"http/1.1"},
+				ALPNProtos:       &[]string{"h2", "http/1.1"},
 				ForwardTimeout:   30 * time.Second,
 			},
 			{
@@ -87,7 +87,7 @@ func TestReadConfig(t *testing.T) {
 				},
 				ForwardRateLimit:   5,
 				Mode:               "HTTPS",
-				ALPNProtos:         &[]string{"http/1.1"},
+				ALPNProtos:         &[]string{"h2", "http/1.1"},
 				InsecureSkipVerify: true,
 				ForwardTimeout:     30 * time.Second,
 			},

--- a/proxy/noquic.go
+++ b/proxy/noquic.go
@@ -45,6 +45,6 @@ func (be *Backend) dialQUICStream(context.Context, string, *tls.Config) (net.Con
 	return nil, errQUICNotEnabled
 }
 
-func (be *Backend) http3ReverseProxy() http.Handler {
+func (be *Backend) http3Transport() http.RoundTripper {
 	return nil
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -637,12 +637,10 @@ func (p *Proxy) Reconfigure(cfg *Config) error {
 				be.http3Handler = be.localHandler()
 			}
 
-		case ModeHTTPS:
+		case ModeHTTPS, ModeHTTP:
 			if cfg.EnableQUIC && be.ALPNProtos != nil && slices.Contains(*be.ALPNProtos, "h3") {
 				be.http3Handler = be.reverseProxy()
 			}
-			fallthrough
-		case ModeHTTP:
 			be.httpConnChan = make(chan net.Conn)
 			be.httpServer = startInternalHTTPServer(be.reverseProxy(), be.httpConnChan)
 		}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -555,10 +555,10 @@ func (p *Proxy) Reconfigure(cfg *Config) error {
 			}
 		}
 		if be.ALPNProtos != nil {
-			*be.ALPNProtos = slices.DeleteFunc(*be.ALPNProtos, func(p string) bool {
+			tc.NextProtos = slices.Clone(*be.ALPNProtos)
+			tc.NextProtos = slices.DeleteFunc(tc.NextProtos, func(p string) bool {
 				return quicOnlyProtocols[p] && (be.Mode == ModeTLS || be.Mode == ModeTCP)
 			})
-			tc.NextProtos = *be.ALPNProtos
 		}
 		be.tlsConfigQUIC = tc.Clone()
 		be.tlsConfigQUIC.MinVersion = tls.VersionTLS13


### PR DESCRIPTION
### Description

In Reverse Proxy mode (`mode: HTTP` or `mode: HTTPS`), the ALPN protocols that TLSPROXY accepts are specified in `alpnProtos: [...]`, and the protocol to use with the request to the backend is specified with `backendProto: ...`.

This makes it possible, for example, to receive HTTP/3 connections at TLSPROXY and forward the HTTP requests to backends using HTTP/2 or HTTP/1:

```yaml
backends:
- serverNames: [example.com]
  addresses: [192.168.0.100:80]
  mode: http
  alpnProtos: [h3, h2, http/1.1]
  backendProto: h2
```
or
```yaml
backends:
- serverNames: [example.com]
  addresses: [192.168.0.100:80]
  mode: http
  alpnProtos: [h3, h2, http/1.1]
  backendProto: http/1.1
```

If `backendProto` is unspecified, it defaults to `http/1.1`.

If `backendProto` is set explicitly to an empty string, the same protocol used by the client will be used, which is the previous behavior.

### Type of change

* [ ] New feature
* [x] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [x] Cleanup / refactoring
* [ ] Other (please explain)

### How is this change tested ?

* [x] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
