### PR TITLE
Passkey ID refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # TLSPROXY Release Notes
 
+## next
+
+* Add an option to refresh the identity used with passkeys (`refreshInterval`).
+
 ## v0.3.2
 
 * Use the certificate provided by _Let's Encrypt_ to authenticate with backends when backends require client authentication.

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -430,6 +430,11 @@ type ConfigPasskey struct {
 	// be used to authenticate the user before registering their first
 	// passkey.
 	IdentityProvider string `yaml:"identityProvider"`
+	// RefreshInterval is the amount of time after which users must
+	// re-authenticate with the other identity provider.
+	// The value is a go duration, e.g. '500h'
+	// The default value of 0 means no re-authentication is required.
+	RefreshInterval time.Duration `yaml:"refreshInterval"`
 	// Endpoint is a URL on this proxy that will handle the passkey
 	// authentication.
 	Endpoint string `yaml:"endpoint"`

--- a/proxy/internal/passkeys/auth-template.html
+++ b/proxy/internal/passkeys/auth-template.html
@@ -24,13 +24,17 @@
 {{- if eq .Mode "Login" }}
     <a class="button" href="{{.Self}}?get=RegisterNewID&nonce={{.Nonce}}">Register New Identity</a>
 {{- end }}
-{{- if eq .Mode "RegisterNewID" }}
+{{- if ne .Mode "Login" }}
     <a class="button" onclick="switchAccount({{.Self}}+'?get=Login&nonce={{.Nonce}}');">Switch Account</a>
 {{- end }}
   </div>
   <div id="message">
 {{- if eq .Mode "Login" }}
     <div><a class="button big" onclick="loginWithPasskey({{.RedirectURL}},{{.Nonce}});">Login</a></div>
+{{- end }}
+{{- if eq .Mode "RefreshID" }}
+    <div>{{.Email}}</div>
+    <div><a class="button" onclick="loginWithPasskey({{.RedirectURL}},{{.Nonce}});">Refresh ID</a></div>
 {{- end }}
 {{- if eq .Mode "RegisterNewID" }}
     <div>{{.Email}}</div>

--- a/proxy/internal/passkeys/webauthn.js
+++ b/proxy/internal/passkeys/webauthn.js
@@ -145,6 +145,10 @@ function loginWithPasskey(redirectUrl, nonce) {
       } else {
         window.location.reload();
       }
+    } else if (r.result === 'refresh') {
+      if (window.confirm(r.email + ' ID must be refreshed')) {
+        window.location = r.url;
+      }
     }
   })
   .catch(err => {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -324,6 +324,7 @@ func (p *Proxy) Reconfigure(cfg *Config) error {
 		cfg := passkeys.Config{
 			Store:              p.store,
 			Other:              other.identityProvider,
+			RefreshInterval:    pp.RefreshInterval,
 			Endpoint:           pp.Endpoint,
 			EventRecorder:      er,
 			CookieManager:      cm,


### PR DESCRIPTION
### Description

Add an option to refresh the identity used with passkeys.

Passkey SSO uses another identity provider to authenticate the user before their passkey is registered. With this new option, tlsproxy can be configured to re-check the user's identity with the other identity provider after the interval specified in `refreshInterval`. By default, the re-check is not enabled.

### Type of change

* [ ] New feature
* [x] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)


### How is this change tested ?

* [ ] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
