### PR TITLE
Client auth with backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # TLSPROXY Release Notes
 
-next:
+## next
 
+* Use the certificate provided by _Let's Encrypt_ to authenticate with backends when backends require client authentication.
 * go: upgraded github.com/quic-go/quic-go v0.40.0 => v0.40.1 (CVE-2023-49295)
 
 ## v0.3.1

--- a/proxy/backend.go
+++ b/proxy/backend.go
@@ -125,10 +125,11 @@ func (be *Backend) dial(ctx context.Context, protos ...string) (net.Conn, error)
 		return nil, errors.New("no backend addresses")
 	}
 	tc := &tls.Config{
-		InsecureSkipVerify: insecureSkipVerify,
-		ServerName:         serverName,
-		NextProtos:         protos,
-		RootCAs:            rootCAs,
+		InsecureSkipVerify:   insecureSkipVerify,
+		ServerName:           serverName,
+		NextProtos:           protos,
+		RootCAs:              rootCAs,
+		GetClientCertificate: be.getClientCert(ctx),
 		VerifyConnection: func(cs tls.ConnectionState) error {
 			if len(cs.PeerCertificates) == 0 {
 				return errors.New("no certificate")

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -24,6 +24,7 @@
 package proxy
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -322,6 +323,7 @@ type Backend struct {
 	tlsConfig            *tls.Config
 	tlsConfigQUIC        *tls.Config
 	forwardRootCAs       *x509.CertPool
+	getClientCert        func(context.Context) func(*tls.CertificateRequestInfo) (*tls.Certificate, error)
 	pkiMap               map[string]*pki.PKIManager
 	bwLimit              *bwLimit
 	connLimit            *rate.Limiter

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -91,6 +91,7 @@ type Proxy struct {
 	certManager interface {
 		HTTPHandler(fallback http.Handler) http.Handler
 		TLSConfig() *tls.Config
+		GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error)
 	}
 	cfg           *Config
 	ctx           context.Context
@@ -569,6 +570,26 @@ func (p *Proxy) Reconfigure(cfg *Config) error {
 			return quicOnlyProtocols[p]
 		})
 		be.tlsConfig = tc
+
+		be.getClientCert = func(ctx context.Context) func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			serverName := connServerName(ctx.Value(connCtxKey).(net.Conn))
+			return func(cri *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+				// autocert wants a ClientHelloInfo. Create one with reasonable values.
+				hello := &tls.ClientHelloInfo{
+					ServerName:       serverName,
+					SignatureSchemes: cri.SignatureSchemes,
+					SupportedCurves: []tls.CurveID{
+						tls.CurveP256,
+					},
+					CipherSuites: []uint16{
+						tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+						tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+						tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+					},
+				}
+				return p.certManager.GetCertificate(hello)
+			}
+		}
 
 		for _, n := range be.ForwardRootCAs {
 			if be.forwardRootCAs == nil {


### PR DESCRIPTION
### Description

Use the certificate provided by _Let's Encrypt_ to authenticate with backends when backends require client authentication

### Type of change

* [X] New feature
* [ ] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)


### How is this change tested ?

* [x] Unit tests
* [X] Manual tests (explain)
* [ ] Tests are not needed
