### PR TITLE
Implement OCSP Verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## next
 
-* Verify the status of client certificates when OCSP servers are specified.
+* Verify the status of client and server certificates when OCSP servers are specified.
 * Fix bug that prevented the PKI WASM client from loading on chrome 119.
 
 ## v0.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Implement OCSP stapling.
 * Verify the status of client and server certificates when OCSP servers are specified.
 * Fix bug that prevented the PKI WASM client from loading on chrome 119.
+* Handle Internationalized Domain Names correctly.
 * Add an option to refresh the identity used with passkeys (`refreshInterval`).
 
 ## v0.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## next
 
+* Implement OCSP stapling.
 * Verify the status of client and server certificates when OCSP servers are specified.
 * Fix bug that prevented the PKI WASM client from loading on chrome 119.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # TLSPROXY Release Notes
 
+## next
+
+* Verify the status of client certificates when OCSP servers are specified.
+* Fix bug that prevented the PKI WASM client from loading on chrome 119.
+
 ## v0.3.2
 
 * Use the certificate provided by _Let's Encrypt_ to authenticate with backends when backends require client authentication.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Overview of features:
 * [x] Routing based on Server Name Indication (SNI), with optional default route when SNI isn't used.
 * [x] Simple round-robin load balancing between servers.
 * [x] Support any ALPN protocol in TLS, TLSPASSTHROUGH, QUIC, or TCP mode.
+* [x] OCSP stapling and OCSP certificate verification.
 * [x] Use the same address (IPAddr:port) for any number of server names, e.g. foo.example.com and bar.example.com on the same xxx.xxx.xxx.xxx:443.
 
 ```mermaid

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/fxamacker/cbor/v2 v2.5.0
 	github.com/go-test/deep v1.1.0
 	github.com/golang-jwt/jwt/v5 v5.2.0
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/pires/go-proxyproto v0.7.0
 	github.com/quic-go/quic-go v0.40.1
 	github.com/russellhaering/goxmldsig v1.4.0
@@ -29,7 +30,7 @@ require (
 	github.com/stretchr/testify v1.8.4 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/mock v0.3.0 // indirect
-	golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb // indirect
+	golang.org/x/exp v0.0.0-20231214170342-aacd6d4b4611 // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/tools v0.16.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/google/pprof v0.0.0-20231205033806-a5a03c77bf08 h1:PxlBVtIFHR/mtWk2i0
 github.com/google/pprof v0.0.0-20231205033806-a5a03c77bf08/go.mod h1:czg5+yv1E0ZGTi6S6vVK1mke0fV+FaUhNGcd6VRS9Ik=
 github.com/google/pprof v0.0.0-20231212022811-ec68065c825e h1:bwOy7hAFd0C91URzMIEBfr6BAz29yk7Qj0cy6S7DJlU=
 github.com/google/pprof v0.0.0-20231212022811-ec68065c825e/go.mod h1:czg5+yv1E0ZGTi6S6vVK1mke0fV+FaUhNGcd6VRS9Ik=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
@@ -86,6 +88,8 @@ golang.org/x/exp v0.0.0-20231127185646-65229373498e h1:Gvh4YaCaXNs6dKTlfgismwWZK
 golang.org/x/exp v0.0.0-20231127185646-65229373498e/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
 golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb h1:c0vyKkb6yr3KR7jEfJaOSv4lG7xPkbN6r52aJz1d8a8=
 golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
+golang.org/x/exp v0.0.0-20231214170342-aacd6d4b4611 h1:qCEDpW1G+vcj3Y7Fy52pEM1AWm3abj8WimGYejI3SC4=
+golang.org/x/exp v0.0.0-20231214170342-aacd6d4b4611/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
 golang.org/x/mod v0.11.0 h1:bUO06HqtnRcc/7l71XBe4WcqTZ+3AH1J59zWDDwLKgU=
 golang.org/x/mod v0.11.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=

--- a/proxy/backend.go
+++ b/proxy/backend.go
@@ -140,7 +140,7 @@ func (be *Backend) dial(ctx context.Context, protos ...string) (net.Conn, error)
 					return errRevoked
 				}
 			} else if len(cert.OCSPServer) > 0 {
-				if err := be.ocspCache.verifyChains(cs.VerifiedChains); err != nil {
+				if err := be.ocspCache.VerifyChains(cs.VerifiedChains); err != nil {
 					be.recordEvent(fmt.Sprintf("backend X509 %s [%s] (OCSP:%v)", cs.ServerName, cert.Subject, err))
 					return errRevoked
 				}

--- a/proxy/backend.go
+++ b/proxy/backend.go
@@ -140,7 +140,7 @@ func (be *Backend) dial(ctx context.Context, protos ...string) (net.Conn, error)
 					return errRevoked
 				}
 			} else if len(cert.OCSPServer) > 0 {
-				if err := be.ocspCache.VerifyChains(cs.VerifiedChains); err != nil {
+				if err := be.ocspCache.VerifyChains(cs.VerifiedChains, cs.OCSPResponse); err != nil {
 					be.recordEvent(fmt.Sprintf("backend X509 %s [%s] (OCSP:%v)", cs.ServerName, cert.Subject, err))
 					return errRevoked
 				}

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -42,6 +42,7 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/net/idna"
 	"golang.org/x/time/rate"
 	yaml "gopkg.in/yaml.v3"
 
@@ -771,7 +772,11 @@ func (cfg *Config) Check() error {
 	beKeys := make(map[beKey]bool)
 	for i, be := range cfg.Backends {
 		for j, sn := range be.ServerNames {
-			sn = strings.ToLower(sn)
+			if asc, err := idna.Lookup.ToASCII(sn); err != nil {
+				return fmt.Errorf("backend[%d].ServerNames[%d]: %v", i, j, err)
+			} else {
+				sn = asc
+			}
 			be.ServerNames[j] = sn
 			if serverNames[sn] == nil {
 				serverNames[sn] = be

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -325,6 +325,7 @@ type Backend struct {
 	forwardRootCAs       *x509.CertPool
 	getClientCert        func(context.Context) func(*tls.CertificateRequestInfo) (*tls.Certificate, error)
 	pkiMap               map[string]*pki.PKIManager
+	ocspCache            *ocspCache
 	bwLimit              *bwLimit
 	connLimit            *rate.Limiter
 	proxyProtocolVersion byte

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -46,6 +46,7 @@ import (
 	yaml "gopkg.in/yaml.v3"
 
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/cookiemanager"
+	"github.com/c2FmZQ/tlsproxy/proxy/internal/ocspcache"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/pki"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/tokenmanager"
 )
@@ -325,7 +326,7 @@ type Backend struct {
 	forwardRootCAs       *x509.CertPool
 	getClientCert        func(context.Context) func(*tls.CertificateRequestInfo) (*tls.Certificate, error)
 	pkiMap               map[string]*pki.PKIManager
-	ocspCache            *ocspCache
+	ocspCache            *ocspcache.OCSPCache
 	bwLimit              *bwLimit
 	connLimit            *rate.Limiter
 	proxyProtocolVersion byte

--- a/proxy/internal/ocspcache/ocsp.go
+++ b/proxy/internal/ocspcache/ocsp.go
@@ -26,6 +26,7 @@ package ocspcache
 import (
 	"bytes"
 	"context"
+	"crypto"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/hex"
@@ -198,7 +199,7 @@ func (c *OCSPCache) Response(cert, issuer *x509.Certificate, margin time.Duratio
 }
 
 func (c *OCSPCache) fetchOCSP(cert, issuer *x509.Certificate) (*ocsp.Response, error) {
-	ocspReq, err := ocsp.CreateRequest(cert, issuer, nil)
+	ocspReq, err := ocsp.CreateRequest(cert, issuer, &ocsp.RequestOptions{Hash: crypto.SHA256})
 	if err != nil {
 		log.Printf("ERR ocsp.CreateRequest: %v", err)
 		return nil, errOCSPInternal

--- a/proxy/internal/pki/http.go
+++ b/proxy/internal/pki/http.go
@@ -493,7 +493,9 @@ func (m *PKIManager) handleStaticFile(w http.ResponseWriter, req *http.Request) 
 	if strings.HasSuffix(file, ".bz2") {
 		rr = bzip2.NewReader(r)
 	}
-	if t := mime.TypeByExtension(filepath.Ext(file)); t != "" {
+	if file == "pki.wasm.bz2" {
+		w.Header().Set("content-type", "application/wasm")
+	} else if t := mime.TypeByExtension(filepath.Ext(file)); t != "" {
 		w.Header().Set("content-type", t)
 	}
 	etag, ok := staticEtags[file]

--- a/proxy/ocsp.go
+++ b/proxy/ocsp.go
@@ -1,0 +1,226 @@
+// MIT License
+//
+// Copyright (c) 2023 TTBT Enterprises LLC
+// Copyright (c) 2023 Robin Thellend <rthellend@rthellend.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"errors"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/c2FmZQ/storage"
+	lru "github.com/hashicorp/golang-lru/v2"
+	"golang.org/x/crypto/ocsp"
+)
+
+const (
+	ocspCacheSize = 200
+	ocspFile      = "ocsp-cache"
+)
+
+var (
+	errOCSPRevoked  = errors.New("revoked cert")
+	errOCSPUnknown  = errors.New("unknown cert")
+	errOCSPProtocol = errors.New("protocol error")
+	errOCSPInternal = errors.New("internal error")
+)
+
+func newOCSPCache(store *storage.Storage) *ocspCache {
+	var empty []ocspCacheItem
+	store.CreateEmptyFile(ocspFile, &empty)
+	c, err := lru.New2Q[string, *ocsp.Response](ocspCacheSize)
+	if err != nil {
+		log.Panicf("newOCSPCache: %v", err)
+	}
+	cache := &ocspCache{
+		store: store,
+		cache: c,
+	}
+	cache.load()
+	return cache
+}
+
+type ocspCache struct {
+	store *storage.Storage
+	cache *lru.TwoQueueCache[string, *ocsp.Response]
+}
+
+type ocspCacheItem struct {
+	Key   string
+	Value []byte
+}
+
+func (c *ocspCache) load() {
+	var items []ocspCacheItem
+	if err := c.store.ReadDataFile(ocspFile, &items); err != nil {
+		log.Printf("ERR OCSP ReadDataFile: %v", err)
+		return
+	}
+	now := time.Now()
+	for _, item := range items {
+		if resp, err := ocsp.ParseResponse(item.Value, nil); err == nil && now.Before(resp.NextUpdate) {
+			c.cache.Add(item.Key, resp)
+		}
+	}
+}
+
+func (c *ocspCache) flushLoop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(time.Minute):
+			if err := c.flush(); err != nil {
+				log.Printf("ERR OCSP flush: %v", err)
+			}
+		}
+	}
+}
+
+func (c *ocspCache) flush() error {
+	var items []ocspCacheItem
+	for _, k := range c.cache.Keys() {
+		if v, ok := c.cache.Peek(k); ok {
+			items = append(items, ocspCacheItem{
+				Key:   k,
+				Value: v.Raw,
+			})
+		}
+	}
+	return c.store.SaveDataFile(ocspFile, &items)
+}
+
+func (c *ocspCache) verifyChains(chains [][]*x509.Certificate) error {
+	var lastError error
+nextChain:
+	for _, chain := range chains {
+		for i, cert := range chain {
+			if len(cert.OCSPServer) == 0 {
+				continue
+			}
+			issuer := cert
+			if i+1 < len(chain) {
+				issuer = chain[i+1]
+			}
+			resp, err := c.getResponse(cert, issuer)
+			if err == errOCSPInternal {
+				continue
+			}
+			if err != nil {
+				lastError = err
+				continue nextChain
+			}
+			switch resp.Status {
+			case ocsp.Revoked:
+				log.Printf("BAD OCSP: %q is revoked", cert.Subject.String())
+				lastError = errOCSPRevoked
+				continue nextChain
+			case ocsp.Unknown:
+				log.Printf("BAD OCSP: %q is unknown", cert.Subject.String())
+				lastError = errOCSPUnknown
+				continue nextChain
+			case ocsp.Good:
+				log.Printf("INF OCSP: %q is GOOD", cert.Subject.String())
+				lastError = nil
+			default:
+				log.Printf("BAD OCSP: %q has unexpected status %v", cert.Subject.String(), resp.Status)
+				lastError = errOCSPProtocol
+				continue nextChain
+			}
+		}
+		// Every cert in the chain is good.
+		break
+	}
+	return lastError
+}
+
+func certHash(b []byte) string {
+	hash := sha256.Sum256(b)
+	return hex.EncodeToString(hash[:])
+}
+
+func (c *ocspCache) getResponse(cert, issuer *x509.Certificate) (*ocsp.Response, error) {
+	hash := certHash(cert.Raw)
+	if resp, ok := c.cache.Get(hash); ok && time.Now().Before(resp.NextUpdate) {
+		return resp, nil
+	}
+	resp, err := fetchOCSP(cert, issuer)
+	if err == nil {
+		c.cache.Add(hash, resp)
+	}
+	return resp, err
+}
+
+func fetchOCSP(cert, issuer *x509.Certificate) (*ocsp.Response, error) {
+	ocspReq, err := ocsp.CreateRequest(cert, issuer, nil)
+	if err != nil {
+		log.Printf("ERR ocsp.CreateRequest: %v", err)
+		return nil, errOCSPInternal
+	}
+	var ocspResp *ocsp.Response
+	for _, server := range cert.OCSPServer {
+		ocspResp, err = fetchOneOCSP(issuer, ocspReq, server)
+		if err != nil || ocspResp.Status == ocsp.Unknown {
+			continue
+		}
+		if err == nil {
+			break
+		}
+	}
+	return ocspResp, err
+}
+
+func fetchOneOCSP(issuer *x509.Certificate, ocspReq []byte, server string) (*ocsp.Response, error) {
+	httpReq, err := http.NewRequest(http.MethodPost, server, bytes.NewReader(ocspReq))
+	if err != nil {
+		log.Printf("ERR http.NewRequest: %v", err)
+		return nil, errOCSPInternal
+	}
+	httpReq.Header.Set("content-type", "application/ocsp-request")
+	httpReq.Header.Set("accept", "application/ocsp-response")
+	httpReq.Header.Set("user-agent", "tlsproxy")
+	httpResp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		log.Printf("ERR %s: %v", server, err)
+		return nil, errOCSPProtocol
+	}
+	defer httpResp.Body.Close()
+	body, err := io.ReadAll(&io.LimitedReader{R: httpResp.Body, N: 4096})
+	if err != nil {
+		log.Printf("ERR body: %v", err)
+		return nil, errOCSPProtocol
+	}
+	ocspResp, err := ocsp.ParseResponse(body, issuer)
+	if err != nil {
+		log.Printf("ERR ocsp.ParseResponse: %v", err)
+		return nil, errOCSPProtocol
+	}
+	return ocspResp, nil
+}

--- a/proxy/ocsp.go
+++ b/proxy/ocsp.go
@@ -106,8 +106,12 @@ func (c *ocspCache) flushLoop(ctx context.Context) {
 
 func (c *ocspCache) flush() error {
 	var items []ocspCacheItem
+	now := time.Now()
 	for _, k := range c.cache.Keys() {
 		if v, ok := c.cache.Peek(k); ok {
+			if now.After(v.NextUpdate) {
+				continue
+			}
 			items = append(items, ocspCacheItem{
 				Key:   k,
 				Value: v.Raw,

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -960,6 +960,8 @@ func (p *Proxy) baseTLSConfig() *tls.Config {
 		}
 		if ocspResp, err := p.ocspCache.Response(cert.Leaf, issuer, time.Hour); err == nil && ocspResp.Status == ocsp.Good {
 			cert.OCSPStaple = ocspResp.Raw
+		} else {
+			p.recordEvent("ocsp staple error for " + hello.ServerName)
 		}
 		return cert, nil
 	}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -870,7 +870,7 @@ func newTestProxy(cfg *Config, cm *certmanager.CertManager) *Proxy {
 		connections:  make(map[connKey]*netw.Conn),
 		store:        store,
 		tokenManager: tm,
-		ocspCache:    newOCSPCache(),
+		ocspCache:    newOCSPCache(store),
 		bwLimits:     make(map[string]*bwLimit),
 	}
 	p.Reconfigure(cfg)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -870,6 +870,7 @@ func newTestProxy(cfg *Config, cm *certmanager.CertManager) *Proxy {
 		connections:  make(map[connKey]*netw.Conn),
 		store:        store,
 		tokenManager: tm,
+		ocspCache:    newOCSPCache(),
 		bwLimits:     make(map[string]*bwLimit),
 	}
 	p.Reconfigure(cfg)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -44,11 +44,13 @@ import (
 
 	"github.com/c2FmZQ/storage"
 	"github.com/c2FmZQ/storage/crypto"
+	"github.com/pires/go-proxyproto"
+
 	"github.com/c2FmZQ/tlsproxy/certmanager"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/netw"
+	"github.com/c2FmZQ/tlsproxy/proxy/internal/ocspcache"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/pki"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/tokenmanager"
-	"github.com/pires/go-proxyproto"
 )
 
 func TestProxyBackends(t *testing.T) {
@@ -870,7 +872,7 @@ func newTestProxy(cfg *Config, cm *certmanager.CertManager) *Proxy {
 		connections:  make(map[connKey]*netw.Conn),
 		store:        store,
 		tokenManager: tm,
-		ocspCache:    newOCSPCache(store),
+		ocspCache:    ocspcache.New(store),
 		bwLimits:     make(map[string]*bwLimit),
 	}
 	p.Reconfigure(cfg)

--- a/proxy/quic.go
+++ b/proxy/quic.go
@@ -518,7 +518,7 @@ func (be *Backend) dialQUICBackend(ctx context.Context, proto string) (*netw.QUI
 					return errRevoked
 				}
 			} else if len(cert.OCSPServer) > 0 {
-				if err := be.ocspCache.VerifyChains(cs.VerifiedChains); err != nil {
+				if err := be.ocspCache.VerifyChains(cs.VerifiedChains, cs.OCSPResponse); err != nil {
 					be.recordEvent(fmt.Sprintf("backend X509 %s [%s] (OCSP:%v)", cs.ServerName, cert.Subject, err))
 					return errRevoked
 				}

--- a/proxy/quic.go
+++ b/proxy/quic.go
@@ -518,7 +518,7 @@ func (be *Backend) dialQUICBackend(ctx context.Context, proto string) (*netw.QUI
 					return errRevoked
 				}
 			} else if len(cert.OCSPServer) > 0 {
-				if err := be.ocspCache.verifyChains(cs.VerifiedChains); err != nil {
+				if err := be.ocspCache.VerifyChains(cs.VerifiedChains); err != nil {
 					be.recordEvent(fmt.Sprintf("backend X509 %s [%s] (OCSP:%v)", cs.ServerName, cert.Subject, err))
 					return errRevoked
 				}


### PR DESCRIPTION
### Description

Implement OCSP stapling and verification of client and backend server certificates. The OCSP responses are cached locally until they expire.

### Type of change

* [x] New feature
* [ ] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)


### How is this change tested ?

* [ ] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
