### PR TITLE
Change some config defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # TLSPROXY Release Notes
 
+## v0.4.0
+
+* This version changes these config options:
+  * `enableQUIC` now defaults to `true` if the binary is compiled with QUIC support, e.g. `+quic` releases.
+  * `alpnProtos` now includes `h3` by default when QUIC is enabled and mode is one of `HTTP`, `HTTPS`, `QUIC`, `LOCAL`, or `CONSOLE`.
+  * `revokeUnusedCertificates` now defaults to `true`, and revocation is only done at the time the proxy starts.
+
 ## v0.3.5
 
 * Add missing lock in revoke.go

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ flowchart LR
 ```yaml
 # Indicate acceptance of the Let's Encrypt Terms of Service.
 acceptTOS: true
+# The email address is used by Let's Encrypt to send important notifications.
+email: <your email address>
 
 # The HTTP address must be reachable from the internet via port 80 for the
 # letsencrypt ACME http-01 challenge to work. If the httpAddr is empty, the

--- a/proxy/config_test.go
+++ b/proxy/config_test.go
@@ -137,6 +137,15 @@ func TestReadConfig(t *testing.T) {
 			},
 		},
 	}
+	v := quicIsEnabled
+	want.EnableQUIC = &v
+	if quicIsEnabled {
+		for _, be := range want.Backends {
+			if be.Mode == ModeHTTP || be.Mode == ModeHTTPS {
+				be.ALPNProtos = defaultALPNProtosPlusH3
+			}
+		}
+	}
 
 	if diff := deep.Equal(want, got); diff != nil {
 		t.Errorf("ReadConfig() = %#v, want %#v", got, want)

--- a/proxy/quic_test.go
+++ b/proxy/quic_test.go
@@ -59,11 +59,10 @@ func TestQUICConnections(t *testing.T) {
 	be2 := newQUICServer(t, ctx, "QUIC Backend", []string{"h3", "imap"}, intCA)
 
 	cfg := &Config{
-		HTTPAddr:   "localhost:0",
-		TLSAddr:    "localhost:0",
-		EnableQUIC: true,
-		CacheDir:   t.TempDir(),
-		MaxOpen:    1000,
+		HTTPAddr: "localhost:0",
+		TLSAddr:  "localhost:0",
+		CacheDir: t.TempDir(),
+		MaxOpen:  1000,
 		Backends: []*Backend{
 			// TCP backend
 			{
@@ -177,11 +176,10 @@ func TestQUICMultiStream(t *testing.T) {
 	}()
 
 	cfg := &Config{
-		HTTPAddr:   "localhost:0",
-		TLSAddr:    "localhost:0",
-		EnableQUIC: true,
-		CacheDir:   t.TempDir(),
-		MaxOpen:    1000,
+		HTTPAddr: "localhost:0",
+		TLSAddr:  "localhost:0",
+		CacheDir: t.TempDir(),
+		MaxOpen:  1000,
 		Backends: []*Backend{
 			{
 				ServerNames: []string{

--- a/proxy/revoke.go
+++ b/proxy/revoke.go
@@ -104,7 +104,7 @@ func (p *Proxy) RevokeAllCertificates(ctx context.Context, reason string) error 
 }
 
 func (p *Proxy) revokeUnusedCertificates(ctx context.Context) error {
-	actuallyRevoke := p.cfg.RevokeUnusedCertificates != nil && *p.cfg.RevokeUnusedCertificates
+	actuallyRevoke := p.cfg.RevokeUnusedCertificates == nil || *p.cfg.RevokeUnusedCertificates
 
 	names := make(map[string]bool)
 	p.mu.Lock()


### PR DESCRIPTION
### Description

Change the default values of some configuration options:
  * `enableQUIC` now defaults to `true` if the binary is compiled with QUIC support, e.g. `+quic` releases.
  * `alpnProtos` now includes `h3` by default when QUIC is enabled and mode is one of `HTTP`, `HTTPS`, `QUIC`, `LOCAL`, or `CONSOLE`.
  * `revokeUnusedCertificates` now defaults to `true`, and revocation is only done at the time the proxy starts.

### Type of change

* [ ] New feature
* [x] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)


### How is this change tested ?

* [x] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
