### PR TITLE
Use proper tls errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # TLSPROXY Release Notes
 
 * Return the proper TLS error when a QUIC client requests an unknown server name and/or alpn protocol.
+* Return the proper TLS error when a client certificate is revoked.
 
 ## v0.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # TLSPROXY Release Notes
 
+* Return the proper TLS error when a QUIC client requests an unknown server name and/or alpn protocol.
+
 ## v0.4.2
 
 * Minor changes to the metrics page: combine runtime and memory profile, add config.

--- a/proxy/backend.go
+++ b/proxy/backend.go
@@ -212,7 +212,7 @@ func (be *Backend) authorize(cert *x509.Certificate) error {
 			return nil
 		}
 	}
-	return errAccessDenied
+	return tlsAccessDenied
 }
 
 func (be *Backend) checkIP(addr net.Addr) error {

--- a/proxy/backend.go
+++ b/proxy/backend.go
@@ -106,17 +106,17 @@ func (be *Backend) dial(ctx context.Context, protos ...string) (net.Conn, error)
 		GetClientCertificate: be.getClientCert(ctx),
 		VerifyConnection: func(cs tls.ConnectionState) error {
 			if len(cs.PeerCertificates) == 0 {
-				return errors.New("no certificate")
+				return tlsCertificateRequired
 			}
 			cert := cs.PeerCertificates[0]
 			if m, ok := be.pkiMap[hex.EncodeToString(cert.AuthorityKeyId)]; ok {
 				if m.IsRevoked(cert.SerialNumber) {
-					return errRevoked
+					return tlsCertificateRevoked
 				}
 			} else if len(cert.OCSPServer) > 0 {
 				if err := be.ocspCache.VerifyChains(cs.VerifiedChains, cs.OCSPResponse); err != nil {
 					be.recordEvent(fmt.Sprintf("backend X509 %s [%s] (OCSP:%v)", idnaToUnicode(cs.ServerName), cert.Subject, err))
-					return errRevoked
+					return tlsCertificateRevoked
 				}
 			}
 			return nil

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -81,11 +81,15 @@ const (
 	internalConnKey  = "ic"
 	reportEndKey     = "re"
 	backendKey       = "be"
+
+	tlsCertificateRevoked  = tls.AlertError(0x2c)
+	tlsAccessDenied        = tls.AlertError(0x31)
+	tlsUnrecognizedName    = tls.AlertError(0x70)
+	tlsCertificateRequired = tls.AlertError(0x74)
 )
 
 var (
 	errAccessDenied = errors.New("access denied")
-	errRevoked      = errors.New("revoked")
 )
 
 // Proxy receives TLS connections and forwards them to the configured
@@ -555,24 +559,24 @@ func (p *Proxy) Reconfigure(cfg *Config) error {
 					return nil
 				}
 				if len(cs.PeerCertificates) == 0 {
-					return errors.New("no certificate")
+					return tlsCertificateRequired
 				}
 				cert := cs.PeerCertificates[0]
 				sum := certSummary(cert)
 				if m, ok := be.pkiMap[hex.EncodeToString(cert.AuthorityKeyId)]; ok {
 					if m.IsRevoked(cert.SerialNumber) {
 						p.recordEvent(fmt.Sprintf("deny X509 [%s] to %s (revoked)", sum, idnaToUnicode(cs.ServerName)))
-						return fmt.Errorf("%w [%s]", errRevoked, sum)
+						return tlsCertificateRevoked
 					}
 				} else if len(cert.OCSPServer) > 0 {
 					if err := p.ocspCache.VerifyChains(cs.VerifiedChains, cs.OCSPResponse); err != nil {
 						p.recordEvent(fmt.Sprintf("deny X509 [%s] to %s (OCSP:%v)", sum, idnaToUnicode(cs.ServerName), err))
-						return fmt.Errorf("%w [%s]", errRevoked, sum)
+						return tlsCertificateRevoked
 					}
 				}
 				if err := be.authorize(cert); err != nil {
 					p.recordEvent(fmt.Sprintf("deny X509 [%s] to %s", sum, idnaToUnicode(cs.ServerName)))
-					return fmt.Errorf("%w [%s]", err, sum)
+					return tlsAccessDenied
 				}
 				if sum != "" {
 					p.recordEvent(fmt.Sprintf("allow X509 [%s] to %s", sum, idnaToUnicode(cs.ServerName)))
@@ -1113,9 +1117,9 @@ func (p *Proxy) authorizeTLSConnection(conn *tls.Conn) bool {
 		switch {
 		case err.Error() == "tls: client didn't provide a certificate":
 			p.recordEvent(fmt.Sprintf("deny no cert to %s", idnaToUnicode(serverName)))
-		case errors.Is(err, errAccessDenied):
+		case errors.Is(err, tlsAccessDenied):
 			p.recordEvent("access denied")
-		case errors.Is(err, errRevoked):
+		case errors.Is(err, tlsCertificateRevoked):
 			p.recordEvent("cert is revoked")
 		default:
 			p.recordEvent("tls handshake failed")

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -563,9 +563,8 @@ func (p *Proxy) Reconfigure(cfg *Config) error {
 					p.recordEvent(fmt.Sprintf("deny no cert to %s", idnaToUnicode(cs.ServerName)))
 					if cs.Version == tls.VersionTLS12 {
 						return tlsBadCertificate
-					} else {
-						return tlsCertificateRequired
 					}
+					return tlsCertificateRequired
 				}
 				cert := cs.PeerCertificates[0]
 				sum := certSummary(cert)

--- a/proxy/quic.go
+++ b/proxy/quic.go
@@ -50,6 +50,8 @@ const (
 	quicIsEnabled         = true
 	statelessResetKeyFile = "quic-stateless-reset-key"
 
+	tlsUnrecognizedName = tls.AlertError(0x70)
+
 	quicUnrecognizedName = quic.ApplicationErrorCode(0x1001)
 	quicAccessDenied     = quic.ApplicationErrorCode(0x1002)
 	quicBadGateway       = quic.ApplicationErrorCode(0x1003)
@@ -81,10 +83,7 @@ func (p *Proxy) startQUIC(ctx context.Context) error {
 			}
 		}
 		log.Printf("ERR QUIC connection %s %s", hello.ServerName, hello.SupportedProtos)
-		return nil, &quic.ApplicationError{
-			ErrorCode:    quicUnrecognizedName,
-			ErrorMessage: fmt.Sprintf("unrecognized name: %s", hello.ServerName),
-		}
+		return nil, tlsUnrecognizedName
 	}
 	qt, err := netw.NewQUIC(p.cfg.TLSAddr, statelessResetKey)
 	if err != nil {


### PR DESCRIPTION
### Description

When the QUIC client requests an unknown server name or protocol, return a proper TLS error.

```
2024/01/02 08:09:07 ERR: CRYPTO_ERROR 0x170 (remote): tls: unrecognized name
```

Do the same thing for revoked certificates, and access denied errors.

### Type of change

* [ ] New feature
* [ ] Feature improvement
* [x] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)


### How is this change tested ?

* [ ] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
