### PR TITLE
Remove a layer of connection wrappers

### DIFF
--- a/proxy/internal/netw/netw.go
+++ b/proxy/internal/netw/netw.go
@@ -106,12 +106,6 @@ func (c *Conn) StreamID() int64 {
 
 // SetAnnotation sets an annotation. The value can be any go value.
 func (c *Conn) SetAnnotation(key string, value any) {
-	if cc, ok := c.Conn.(interface {
-		SetAnnotation(key string, value any)
-	}); ok {
-		cc.SetAnnotation(key, value)
-		return
-	}
 	SetAnnotation(c, key, value)
 }
 
@@ -132,11 +126,6 @@ func SetAnnotation(conn net.Conn, key string, value any) {
 // Annotation retrieves an annotation that was previously set on the connection.
 // The defaultValue is returned if the annotation was never set.
 func (c *Conn) Annotation(key string, defaultValue any) any {
-	if cc, ok := c.Conn.(interface {
-		Annotation(key string, defaultValue any) any
-	}); ok {
-		return cc.Annotation(key, defaultValue)
-	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if v, ok := c.annotations[key]; ok {
@@ -148,66 +137,34 @@ func (c *Conn) Annotation(key string, defaultValue any) any {
 // SetLimiter sets the rate limiters for this connection.
 // It must be called before the first Read() or Write(). Peek() is OK.
 func (c *Conn) SetLimiters(ingress, egress *rate.Limiter) {
-	if cc, ok := c.Conn.(interface {
-		SetLimiters(ingress, egress *rate.Limiter)
-	}); ok {
-		cc.SetLimiters(ingress, egress)
-		return
-	}
 	c.ingressLimiter = ingress
 	c.egressLimiter = egress
 }
 
 func (c *Conn) SetCounters(sent, received *counter.Counter) {
-	if cc, ok := c.Conn.(interface {
-		SetCounters(sent, received *counter.Counter)
-	}); ok {
-		cc.SetCounters(sent, received)
-		return
-	}
 	c.upBytesSent = sent
 	c.upBytesReceived = received
 }
 
 // BytesSent returns the number of bytes sent on this connection so far.
 func (c *Conn) BytesSent() int64 {
-	if cc, ok := c.Conn.(interface {
-		BytesSent() int64
-	}); ok {
-		return cc.BytesSent()
-	}
 	return c.bytesSent.Value()
 }
 
 // BytesReceived returns the number of bytes received on this connection so far.
 func (c *Conn) BytesReceived() int64 {
-	if cc, ok := c.Conn.(interface {
-		BytesReceived() int64
-	}); ok {
-		return cc.BytesReceived()
-	}
 	return c.bytesReceived.Value()
 }
 
 // ByteRateSent returns the rate of bytes sent on this connection in the last
 // minute.
 func (c *Conn) ByteRateSent() float64 {
-	if cc, ok := c.Conn.(interface {
-		ByteRateSent() float64
-	}); ok {
-		return cc.ByteRateSent()
-	}
 	return c.bytesSent.Rate(time.Minute)
 }
 
 // ByteRateReceived returns the rate of bytes received on this connection in the
 // last minute.
 func (c *Conn) ByteRateReceived() float64 {
-	if cc, ok := c.Conn.(interface {
-		ByteRateReceived() float64
-	}); ok {
-		return cc.ByteRateReceived()
-	}
 	return c.bytesReceived.Rate(time.Minute)
 }
 

--- a/proxy/internal/netw/netw.go
+++ b/proxy/internal/netw/netw.go
@@ -28,7 +28,6 @@ package netw
 import (
 	"context"
 	"io"
-	"maps"
 	"net"
 	"sync"
 	"time"
@@ -144,14 +143,6 @@ func (c *Conn) Annotation(key string, defaultValue any) any {
 		return v
 	}
 	return defaultValue
-}
-
-func (c *Conn) CopyAnnotationsFrom(cc *Conn) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	cc.mu.Lock()
-	defer cc.mu.Unlock()
-	maps.Copy(c.annotations, cc.annotations)
 }
 
 // SetLimiter sets the rate limiters for this connection.

--- a/proxy/internal/netw/netw.go
+++ b/proxy/internal/netw/netw.go
@@ -163,6 +163,7 @@ func (c *Conn) SetCounters(sent, received *counter.Counter) {
 		SetCounters(sent, received *counter.Counter)
 	}); ok {
 		cc.SetCounters(sent, received)
+		return
 	}
 	c.upBytesSent = sent
 	c.upBytesReceived = received

--- a/proxy/internal/netw/noquic.go
+++ b/proxy/internal/netw/noquic.go
@@ -45,3 +45,26 @@ type QUICConn struct {
 func (*QUICConn) Streams() []*QUICStream {
 	return nil
 }
+
+func (*QUICConn) Annotation(key string, defaultValue any) any {
+	return nil
+}
+
+func (*QUICConn) SetAnnotation(key string, value any) {
+}
+
+func (*QUICConn) BytesSent() int64 {
+	return 0
+}
+
+func (*QUICConn) BytesReceived() int64 {
+	return 0
+}
+
+func (*QUICConn) ByteRateSent() float64 {
+	return 0
+}
+
+func (*QUICConn) ByteRateReceived() float64 {
+	return 0
+}

--- a/proxy/internal/netw/quic.go
+++ b/proxy/internal/netw/quic.go
@@ -144,11 +144,33 @@ type QUICConn struct {
 
 	mu              sync.Mutex
 	onClose         func()
+	annotations     map[string]any
 	bytesSent       *counter.Counter
 	bytesReceived   *counter.Counter
 	upBytesSent     *counter.Counter
 	upBytesReceived *counter.Counter
 	streams         []*QUICStream
+}
+
+// SetAnnotation sets an annotation. The value can be any go value.
+func (c *QUICConn) SetAnnotation(key string, value any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.annotations == nil {
+		c.annotations = make(map[string]any)
+	}
+	c.annotations[key] = value
+}
+
+// Annotation retrieves an annotation that was previously set on the connection.
+// The defaultValue is returned if the annotation was never set.
+func (c *QUICConn) Annotation(key string, defaultValue any) any {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if v, ok := c.annotations[key]; ok {
+		return v
+	}
+	return defaultValue
 }
 
 func (c *QUICConn) Streams() []*QUICStream {

--- a/proxy/metrics.go
+++ b/proxy/metrics.go
@@ -71,7 +71,11 @@ func (p *Proxy) addConn(c *netw.Conn) int {
 	return len(p.connections)
 }
 
-func (p *Proxy) setCounters(c *netw.Conn, serverName string) {
+type counterSetter interface {
+	SetCounters(*counter.Counter, *counter.Counter)
+}
+
+func (p *Proxy) setCounters(c counterSetter, serverName string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.metrics == nil {

--- a/proxy/metrics.go
+++ b/proxy/metrics.go
@@ -28,7 +28,6 @@ import (
 	_ "embed"
 	"fmt"
 	"html/template"
-	"net"
 	"net/http"
 	"runtime"
 	"runtime/debug"
@@ -64,10 +63,16 @@ func (p *Proxy) recordEvent(msg string) {
 	p.events[msg]++
 }
 
-func (p *Proxy) addConn(c *netw.Conn) int {
+func (p *Proxy) addConn(c annotatedConnection) int {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.connections[connKey{c.LocalAddr(), c.RemoteAddr(), c.StreamID()}] = c
+	key := connKey{src: c.LocalAddr(), dst: c.RemoteAddr(), id: -1}
+	if s, ok := c.(interface {
+		StreamID() int64
+	}); ok {
+		key.id = s.StreamID()
+	}
+	p.connections[key] = c
 	return len(p.connections)
 }
 
@@ -94,10 +99,16 @@ func (p *Proxy) setCounters(c counterSetter, serverName string) {
 	c.SetCounters(m.numBytesSent, m.numBytesReceived)
 }
 
-func (p *Proxy) removeConn(c *netw.Conn) int {
+func (p *Proxy) removeConn(c annotatedConnection) int {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	delete(p.connections, connKey{c.LocalAddr(), c.RemoteAddr(), c.StreamID()})
+	key := connKey{src: c.LocalAddr(), dst: c.RemoteAddr(), id: -1}
+	if s, ok := c.(interface {
+		StreamID() int64
+	}); ok {
+		key.id = s.StreamID()
+	}
+	delete(p.connections, key)
 	return len(p.connections)
 }
 
@@ -276,8 +287,8 @@ func (p *Proxy) metricsHandler(w http.ResponseWriter, req *http.Request) {
 		}
 		var streams []*netw.QUICStream
 
-		switch cc := c.Conn.(type) {
-		case *net.TCPConn:
+		switch cc := c.(type) {
+		case *netw.Conn:
 			connection.Type = "TLS"
 		case *netw.QUICConn:
 			connection.Type = "QUIC"
@@ -286,7 +297,7 @@ func (p *Proxy) metricsHandler(w http.ResponseWriter, req *http.Request) {
 				return streams[i].StreamID() < streams[j].StreamID()
 			})
 		default:
-			connection.Type = fmt.Sprintf(" %T", c.Conn)
+			connection.Type = fmt.Sprintf(" %T", c)
 		}
 
 		var intAddr string

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -113,7 +113,7 @@ type Proxy struct {
 	connClosed    *sync.Cond
 	defServerName string
 	backends      map[beKey]*Backend
-	connections   map[connKey]*netw.Conn
+	connections   map[connKey]annotatedConnection
 	pkis          map[string]*pki.PKIManager
 	ocspCache     *ocspcache.OCSPCache
 	bwLimits      map[string]*bwLimit
@@ -193,7 +193,7 @@ func New(cfg *Config, passphrase []byte) (*Proxy, error) {
 		},
 		store:        store,
 		tokenManager: tm,
-		connections:  make(map[connKey]*netw.Conn),
+		connections:  make(map[connKey]annotatedConnection),
 		pkis:         make(map[string]*pki.PKIManager),
 		ocspCache:    ocspcache.New(store),
 		bwLimits:     make(map[string]*bwLimit),
@@ -236,7 +236,7 @@ func NewTestProxy(cfg *Config) (*Proxy, error) {
 	}
 	p := &Proxy{
 		certManager:  cm,
-		connections:  make(map[connKey]*netw.Conn),
+		connections:  make(map[connKey]annotatedConnection),
 		store:        store,
 		tokenManager: tm,
 		pkis:         make(map[string]*pki.PKIManager),
@@ -789,7 +789,7 @@ func (p *Proxy) Reconfigure(cfg *Config) error {
 
 func (p *Proxy) reAuthorize() {
 	p.mu.Lock()
-	conns := make([]*netw.Conn, 0, len(p.connections))
+	conns := make([]annotatedConnection, 0, len(p.connections))
 	for _, c := range p.connections {
 		conns = append(conns, c)
 	}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -49,7 +49,6 @@ import (
 	"github.com/pires/go-proxyproto"
 
 	"github.com/c2FmZQ/tlsproxy/certmanager"
-	"github.com/c2FmZQ/tlsproxy/proxy/internal/netw"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/ocspcache"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/pki"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/tokenmanager"
@@ -880,7 +879,7 @@ func newTestProxy(cfg *Config, cm *certmanager.CertManager) *Proxy {
 	}
 	p := &Proxy{
 		certManager:  cm,
-		connections:  make(map[connKey]*netw.Conn),
+		connections:  make(map[connKey]annotatedConnection),
 		store:        store,
 		tokenManager: tm,
 		ocspCache:    ocspcache.New(store),

--- a/proxy/quic.go
+++ b/proxy/quic.go
@@ -311,7 +311,6 @@ func (p *Proxy) handleQUICConnection(qc *netw.QUICConn) {
 				return
 			}
 			cc := qc.WrapStream(recvStream)
-			cc.CopyAnnotationsFrom(conn)
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -329,7 +328,6 @@ func (p *Proxy) handleQUICConnection(qc *netw.QUICConn) {
 				return
 			}
 			cc := qc.WrapStream(stream)
-			cc.CopyAnnotationsFrom(conn)
 			wg.Add(1)
 			go func() {
 				defer wg.Done()

--- a/proxy/util.go
+++ b/proxy/util.go
@@ -56,6 +56,8 @@ func annotatedConn(c net.Conn) annotatedConnection {
 		return netwConn(c.NetConn())
 	case *netw.Conn:
 		return c
+	case *netw.QUICConn:
+		return c
 	default:
 		panic(c)
 	}

--- a/proxy/util.go
+++ b/proxy/util.go
@@ -45,33 +45,49 @@ func netwConn(c net.Conn) *netw.Conn {
 	}
 }
 
+type annotatedConnection interface {
+	Annotation(key string, defaultValue any) any
+	SetAnnotation(key string, value any)
+}
+
+func annotatedConn(c net.Conn) annotatedConnection {
+	switch c := c.(type) {
+	case *tls.Conn:
+		return netwConn(c.NetConn())
+	case *netw.Conn:
+		return c
+	default:
+		panic(c)
+	}
+}
+
 func connServerNameIsSet(c net.Conn) bool {
-	return netwConn(c).Annotation(serverNameKey, nil) != nil
+	return annotatedConn(c).Annotation(serverNameKey, nil) != nil
 }
 
 func connServerName(c net.Conn) string {
-	if v, ok := netwConn(c).Annotation(serverNameKey, "").(string); ok {
+	if v, ok := annotatedConn(c).Annotation(serverNameKey, "").(string); ok {
 		return v
 	}
 	return ""
 }
 
 func connProto(c net.Conn) string {
-	if v, ok := netwConn(c).Annotation(protoKey, "").(string); ok {
+	if v, ok := annotatedConn(c).Annotation(protoKey, "").(string); ok {
 		return v
 	}
 	return ""
 }
 
 func connClientCert(c net.Conn) *x509.Certificate {
-	if v, ok := netwConn(c).Annotation(clientCertKey, (*x509.Certificate)(nil)).(*x509.Certificate); ok {
+	if v, ok := annotatedConn(c).Annotation(clientCertKey, (*x509.Certificate)(nil)).(*x509.Certificate); ok {
 		return v
 	}
 	return nil
 }
 
 func connBackend(c net.Conn) *Backend {
-	if v, ok := netwConn(c).Annotation(backendKey, (*Backend)(nil)).(*Backend); ok {
+	if v, ok := annotatedConn(c).Annotation(backendKey, (*Backend)(nil)).(*Backend); ok {
 		return v
 	}
 	return nil
@@ -85,7 +101,7 @@ func connMode(c net.Conn) string {
 }
 
 func connIntConn(c net.Conn) net.Conn {
-	if v, ok := netwConn(c).Annotation(internalConnKey, nil).(net.Conn); ok {
+	if v, ok := annotatedConn(c).Annotation(internalConnKey, nil).(net.Conn); ok {
 		return v
 	}
 	return nil

--- a/proxy/util.go
+++ b/proxy/util.go
@@ -46,8 +46,13 @@ func netwConn(c net.Conn) *netw.Conn {
 }
 
 type annotatedConnection interface {
+	net.Conn
 	Annotation(key string, defaultValue any) any
 	SetAnnotation(key string, value any)
+	BytesSent() int64
+	BytesReceived() int64
+	ByteRateSent() float64
+	ByteRateReceived() float64
 }
 
 func annotatedConn(c net.Conn) annotatedConnection {


### PR DESCRIPTION
### Description

Refactor code so that QUICConn doesn't need to be wrapped in net.Conn.

### Type of change

* [ ] New feature
* [ ] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [x] Cleanup / refactoring
* [ ] Other (please explain)


### How is this change tested ?

* [x] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
