### PR TITLE
Add support for the OIDC `hd` param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # TLSPROXY Release Notes
 
+* Add support for the OIDC `hd` param (https://developers.google.com/identity/openid-connect/openid-connect#hd-param).
 * Return the proper TLS error when a QUIC client requests an unknown server name and/or alpn protocol.
 * Return the proper TLS error when a client certificate is revoked.
 

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -405,6 +405,9 @@ type ConfigOIDC struct {
 	// "public_profile"}.
 	Scopes []string `yaml:"scopes,omitempty"`
 	// HostedDomain specifies that the HD param should be used.
+	// This parameter is used by Google is restrict the login process to
+	// one hosted domain, e.g. example.com. An empty or unspecified value
+	// means accounts from any domain will be accepted.
 	// https://developers.google.com/identity/openid-connect/openid-connect#hd-param
 	HostedDomain string `yaml:"hostedDomain,omitempty"`
 	// TokenEndpoint is the token endpoint. It must be set only if

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -404,6 +404,9 @@ type ConfigOIDC struct {
 	// {"openid", "email", "profile"} or {"openid", "email",
 	// "public_profile"}.
 	Scopes []string `yaml:"scopes,omitempty"`
+	// HostedDomain specifies that the HD param should be used.
+	// https://developers.google.com/identity/openid-connect/openid-connect#hd-param
+	HostedDomain string `yaml:"hostedDomain,omitempty"`
 	// TokenEndpoint is the token endpoint. It must be set only if
 	// DiscoveryURL is not set.
 	TokenEndpoint string `yaml:"tokenEndpoint,omitempty"`

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -291,6 +291,7 @@ func (p *Proxy) Reconfigure(cfg *Config) error {
 			RedirectURL:      pp.RedirectURL,
 			ClientID:         pp.ClientID,
 			ClientSecret:     pp.ClientSecret,
+			HostedDomain:     pp.HostedDomain,
 		}
 		provider, err := oidc.New(oidcCfg, er, cm)
 		if err != nil {


### PR DESCRIPTION
### Description

Add support for the OIDC `hd` param. This parameter is used by Google is restrict the login process to one hosted domain, e.g. example.com. An empty or unspecified value means accounts from any domain will be accepted.

https://developers.google.com/identity/openid-connect/openid-connect#hd-param

### Type of change

* [ ] New feature
* [x] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)

### How is this change tested ?

* [ ] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
