### PR TITLE
Improve user experience with the passkey login screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # TLSPROXY Release Notes
 
+* Improve user experience with the passkey login screen.
+
 ## v0.4.3
 
 * Add support for the OIDC `hd` param (https://developers.google.com/identity/openid-connect/openid-connect#hd-param).

--- a/proxy/backend-sso.go
+++ b/proxy/backend-sso.go
@@ -42,6 +42,7 @@ import (
 
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/cookiemanager"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/passkeys"
+	"github.com/c2FmZQ/tlsproxy/proxy/internal/tokenmanager"
 )
 
 type ctxAuthKey struct{}
@@ -326,7 +327,7 @@ func (be *Backend) enforceSSOPolicy(w http.ResponseWriter, req *http.Request) bo
 	be.recordEvent(fmt.Sprintf("allow SSO %s to %s", userID, idnaToUnicode(host)))
 
 	// Filter out the tlsproxy auth cookie.
-	cookiemanager.FilterOutAuthTokenCookie(req, "TLSPROXYSID")
+	cookiemanager.FilterOutAuthTokenCookie(req, tokenmanager.SessionIDCookieName)
 	return true
 }
 

--- a/proxy/backend-sso.go
+++ b/proxy/backend-sso.go
@@ -211,7 +211,7 @@ func (be *Backend) serveLogin(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, "invalid request", http.StatusBadRequest)
 		return
 	}
-	be.SSO.p.RequestLogin(w, req, url)
+	be.SSO.p.RequestLogin(w, req, url.String())
 }
 
 func (be *Backend) serveLogout(w http.ResponseWriter, req *http.Request) {
@@ -225,7 +225,7 @@ func (be *Backend) serveLogout(w http.ResponseWriter, req *http.Request) {
 			http.Error(w, "invalid request", http.StatusBadRequest)
 			return
 		}
-		be.SSO.p.RequestLogin(w, req, url)
+		be.SSO.p.RequestLogin(w, req, url.String())
 		return
 	}
 	logoutTemplate.Execute(w, nil)

--- a/proxy/backend-sso_test.go
+++ b/proxy/backend-sso_test.go
@@ -199,35 +199,6 @@ func TestEnforceSSOPolicy(t *testing.T) {
 	}
 }
 
-func TestTokenForURL(t *testing.T) {
-	proxy := newBackendSSOTestProxy(t)
-
-	req := httptest.NewRequest("GET", "https://example.com/foo/bar", nil)
-	w := httptest.NewRecorder()
-	tok, displayURL, err := proxy.cfg.Backends[0].makeTokenForURL(w, req)
-	if err != nil {
-		t.Errorf("makeTokenForURL() err = %v", err)
-	}
-	if got, want := displayURL, "https://example.com/foo/bar"; got != want {
-		t.Errorf("displayURL = %q, want %q", got, want)
-	}
-
-	// Wrong session id
-	if _, err := proxy.cfg.Backends[0].validateTokenForURL(w, req, tok); err == nil {
-		t.Fatal("validateTokenForURL should fail")
-	}
-
-	// Correct session id
-	req.Header.Set("cookie", w.Header().Get("set-cookie"))
-	u, err := proxy.cfg.Backends[0].validateTokenForURL(w, req, tok)
-	if err != nil {
-		t.Errorf("validateTokenForURL err = %v", err)
-	}
-	if got, want := u, "https://example.com/foo/bar"; got != want {
-		t.Errorf("url = %q, want %q", got, want)
-	}
-}
-
 func newBackendSSOTestProxy(t *testing.T) *Proxy {
 	return newTestProxy(
 		&Config{

--- a/proxy/internal/passkeys/auth-template.html
+++ b/proxy/internal/passkeys/auth-template.html
@@ -40,7 +40,7 @@ a.button.big {
     <div class="big">🛂</div>
     <div>Authentication required to access</div>
     <div id="target"><a href="{{.URL}}">{{.DisplayURL}}</a></div>
-    <div><a class="button big" onclick="loginWithPasskey({{.Token}});">Login</a></div>
+    <div><a class="button big" onclick="loginWithPasskey({{.Token}});">Continue</a></div>
 {{- end }}
 {{- if eq .Mode "RefreshID" }}
     <div>{{.Email}}</div>
@@ -51,7 +51,7 @@ a.button.big {
   {{- if .IsAllowed }}
     {{- if .IsRegistered }}
     <div>Already Registered</div>
-    <div><a class="button" onclick="loginWithPasskey({{.Token}});">Login</a></div>
+    <div><a class="button big" onclick="loginWithPasskey({{.Token}});">Continue</a></div>
     {{- else }}
     <div><a class="button" onclick="registerPasskey({{.Token}});">Register This Identity</a></div>
     {{- end }}

--- a/proxy/internal/passkeys/auth-template.html
+++ b/proxy/internal/passkeys/auth-template.html
@@ -22,28 +22,28 @@
   <div id="sum">Access to this page is controlled using <a href="https://fidoalliance.org/passkeys/">Passkeys</a>.</div>
   <div id="buttons">
 {{- if eq .Mode "Login" }}
-    <a class="button" href="{{.Self}}?get=RegisterNewID&nonce={{.Nonce}}">Register New Identity</a>
+    <a class="button" href="{{.Self}}?get=RegisterNewID&redirect={{.Token}}">Register New Identity</a>
 {{- end }}
 {{- if ne .Mode "Login" }}
-    <a class="button" onclick="switchAccount({{.Self}}+'?get=Login&nonce={{.Nonce}}');">Switch Account</a>
+    <a class="button" onclick="switchAccount({{.Self}}+'?get=Login&redirect={{.Token}}');">Switch Account</a>
 {{- end }}
   </div>
   <div id="message">
 {{- if eq .Mode "Login" }}
-    <div><a class="button big" onclick="loginWithPasskey({{.RedirectURL}},{{.Nonce}});">Login</a></div>
+    <div><a class="button big" onclick="loginWithPasskey({{.Token}});">Login</a></div>
 {{- end }}
 {{- if eq .Mode "RefreshID" }}
     <div>{{.Email}}</div>
-    <div><a class="button" onclick="loginWithPasskey({{.RedirectURL}},{{.Nonce}});">Refresh ID</a></div>
+    <div><a class="button" onclick="loginWithPasskey({{.Token}});">Refresh ID</a></div>
 {{- end }}
 {{- if eq .Mode "RegisterNewID" }}
     <div>{{.Email}}</div>
   {{- if .IsAllowed }}
     {{- if .IsRegistered }}
     <div>Already Registered</div>
-    <div><a class="button" onclick="loginWithPasskey({{.RedirectURL}},{{.Nonce}});">Login</a></div>
+    <div><a class="button" onclick="loginWithPasskey({.Token}});">Login</a></div>
     {{- else }}
-    <div><a class="button" onclick="registerPasskey({{.RedirectURL}},{{.Nonce}});">Register This Identity</a></div>
+    <div><a class="button" onclick="registerPasskey({{.Token}});">Register This Identity</a></div>
     {{- end }}
   {{- else }}
     <div>Is Not Allowed</div>

--- a/proxy/internal/passkeys/auth-template.html
+++ b/proxy/internal/passkeys/auth-template.html
@@ -14,12 +14,19 @@
   text-align: center;
 }
 .big {
+  font-size: 800%;
+}
+a.button.big {
+  line-height: 6rem;
   font-size: 300%;
+}
+#message {
+  width: fit-content;
 }
 </style>
 </head>
 <body>
-  <div id="sum">Access to this page is controlled using <a href="https://fidoalliance.org/passkeys/">Passkeys</a>.</div>
+  <div id="sum">Access to this page is controlled using <a href="https://fidoalliance.org/passkeys/">passkeys</a>.</div>
   <div id="buttons">
 {{- if eq .Mode "Login" }}
     <a class="button" href="{{.Self}}?get=RegisterNewID&redirect={{.Token}}">Register New Identity</a>
@@ -30,6 +37,9 @@
   </div>
   <div id="message">
 {{- if eq .Mode "Login" }}
+    <div class="big">🛂</div>
+    <div>Authentication required to access</div>
+    <div id="target"><a href="{{.URL}}">{{.DisplayURL}}</a></div>
     <div><a class="button big" onclick="loginWithPasskey({{.Token}});">Login</a></div>
 {{- end }}
 {{- if eq .Mode "RefreshID" }}

--- a/proxy/internal/passkeys/auth-template.html
+++ b/proxy/internal/passkeys/auth-template.html
@@ -41,7 +41,7 @@
   {{- if .IsAllowed }}
     {{- if .IsRegistered }}
     <div>Already Registered</div>
-    <div><a class="button" onclick="loginWithPasskey({.Token}});">Login</a></div>
+    <div><a class="button" onclick="loginWithPasskey({{.Token}});">Login</a></div>
     {{- else }}
     <div><a class="button" onclick="registerPasskey({{.Token}});">Register This Identity</a></div>
     {{- end }}

--- a/proxy/internal/passkeys/manager.go
+++ b/proxy/internal/passkeys/manager.go
@@ -432,7 +432,7 @@ func (m *Manager) HandleCallback(w http.ResponseWriter, req *http.Request) {
 		m.setAuthToken(w, originalURL, claims)
 
 	case "Switch":
-		if req.Method != "POST" {
+		if req.Method != "POST" || originalURL == nil {
 			http.Error(w, "invalid request", http.StatusBadRequest)
 			return
 		}
@@ -702,6 +702,10 @@ func (m *Manager) deleteKey(email string, id Bytes) (retErr error) {
 }
 
 func (m *Manager) setAuthToken(w http.ResponseWriter, u *url.URL, claims map[string]any) {
+	if u == nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
 	subject, ok := claims["sub"].(string)
 	if !ok {
 		http.Error(w, "internal error", http.StatusInternalServerError)

--- a/proxy/internal/passkeys/manager.go
+++ b/proxy/internal/passkeys/manager.go
@@ -279,14 +279,9 @@ func (m *Manager) HandleCallback(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, "invalid request", http.StatusBadRequest)
 		return
 	}
-	origURL, err := m.cfg.TokenManager.ValidateURLToken(w, req, redirectToken)
+	originalURL, err := m.cfg.TokenManager.ValidateURLToken(w, req, redirectToken)
 	if err != nil {
 		http.Error(w, "invalid or expired request", http.StatusBadRequest)
-		return
-	}
-	originalURL, err := url.Parse(origURL)
-	if err != nil {
-		http.Error(w, "invalid request", http.StatusBadRequest)
 		return
 	}
 

--- a/proxy/internal/passkeys/manager.go
+++ b/proxy/internal/passkeys/manager.go
@@ -52,6 +52,7 @@ import (
 	jwt "github.com/golang-jwt/jwt/v5"
 
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/cookiemanager"
+	"github.com/c2FmZQ/tlsproxy/proxy/internal/tokenmanager"
 )
 
 const passkeyFile = "passkeys"
@@ -103,6 +104,7 @@ type Config struct {
 	EventRecorder      EventRecorder
 	CookieManager      *cookiemanager.CookieManager
 	OtherCookieManager *cookiemanager.CookieManager
+	TokenManager       *tokenmanager.TokenManager
 	ClaimsFromCtx      func(context.Context) jwt.MapClaims
 }
 
@@ -110,7 +112,7 @@ func NewManager(cfg Config) (*Manager, error) {
 	m := &Manager{
 		cfg:        cfg,
 		challenges: make(map[string]*challenge),
-		nonces:     make(map[string]*passkeyData),
+		nonces:     make(map[string]*nonceData),
 	}
 	m.db.Handles = make(map[string]*user)
 	m.db.Subjects = make(map[string]string)
@@ -133,7 +135,7 @@ type Manager struct {
 	challenges map[string]*challenge
 
 	noncesMu sync.Mutex
-	nonces   map[string]*passkeyData
+	nonces   map[string]*nonceData
 }
 
 type challenge struct {
@@ -142,10 +144,9 @@ type challenge struct {
 	uid     []byte
 }
 
-type passkeyData struct {
+type nonceData struct {
 	created time.Time
-	origURL string
-	host    string
+	origURL *url.URL
 }
 
 func (m *Manager) SetACL(acl *[]string) {
@@ -194,6 +195,7 @@ func (m *Manager) ServeWellKnown(w http.ResponseWriter, req *http.Request) {
 
 func (m *Manager) RequestLogin(w http.ResponseWriter, req *http.Request, origURL string) {
 	m.cfg.EventRecorder.Record("passkey auth request")
+
 	m.noncesMu.Lock()
 	defer m.noncesMu.Unlock()
 
@@ -202,17 +204,16 @@ func (m *Manager) RequestLogin(w http.ResponseWriter, req *http.Request, origURL
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
+	nonce := hex.EncodeToString(n)
 	ou, err := url.Parse(origURL)
 	if err != nil {
 		log.Printf("ERR %q: %v", origURL, err)
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
-	nonce := hex.EncodeToString(n)
-	m.nonces[nonce] = &passkeyData{
+	m.nonces[nonce] = &nonceData{
 		created: time.Now().UTC(),
-		origURL: origURL,
-		host:    ou.Host,
+		origURL: ou,
 	}
 
 	u, err := url.Parse(m.cfg.Endpoint)
@@ -244,13 +245,31 @@ func (m *Manager) HandleCallback(w http.ResponseWriter, req *http.Request) {
 	defer m.noncesMu.Unlock()
 	now := time.Now().UTC()
 	for k, v := range m.nonces {
-		if v.created.Add(time.Hour).Before(now) {
+		if v.created.Add(5 * time.Minute).Before(now) {
 			delete(m.nonces, k)
 		}
 	}
 	req.ParseForm()
 
+	nonce := req.Form.Get("nonce")
+	if nData, ok := m.nonces[nonce]; ok {
+		delete(m.nonces, nonce)
+		token, _, err := m.cfg.TokenManager.URLToken(w, req, nData.origURL)
+		if err != nil {
+			log.Printf("ERR %q: %v", nData.origURL, err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		args := req.URL.Query()
+		args.Del("nonce")
+		args.Set("redirect", token)
+		req.URL.RawQuery = args.Encode()
+		http.Redirect(w, req, req.URL.String(), http.StatusFound)
+		return
+	}
+
 	mode := req.Form.Get("get")
+	redirectToken := req.Form.Get("redirect")
 
 	token, err := m.cfg.OtherCookieManager.ValidateAuthTokenCookie(req)
 	if err != nil {
@@ -268,26 +287,17 @@ func (m *Manager) HandleCallback(w http.ResponseWriter, req *http.Request) {
 
 	switch mode {
 	case "Login", "RegisterNewID", "RefreshID":
-		nonce := req.Form.Get("nonce")
-		d, ok := m.nonces[nonce]
-		if !ok {
-			http.Redirect(w, req, "/", http.StatusFound)
-			return
-		}
-
 		data := struct {
 			Self         string
-			RedirectURL  string
+			Token        string
 			Mode         string
-			Nonce        string
 			Email        string
 			IsAllowed    bool
 			IsRegistered bool
 		}{
-			Self:        req.URL.Path,
-			RedirectURL: d.origURL,
-			Mode:        mode,
-			Nonce:       nonce,
+			Self:  req.URL.Path,
+			Token: redirectToken,
+			Mode:  mode,
 		}
 		if mode == "RegisterNewID" || mode == "RefreshID" {
 			data.Email, _ = token.Claims.(jwt.MapClaims)["email"].(string)
@@ -376,11 +386,17 @@ func (m *Manager) HandleCallback(w http.ResponseWriter, req *http.Request) {
 			}
 		}
 		m.cfg.EventRecorder.Record("passkey check request")
-		var host string
-		if d, ok := m.nonces[req.Form.Get("nonce")]; ok {
-			host = d.host
+		origURL, err := m.cfg.TokenManager.ValidateURLToken(w, req, redirectToken)
+		if err != nil {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
 		}
-		m.setAuthToken(w, host, claims)
+		ou, err := url.Parse(origURL)
+		if err != nil {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		m.setAuthToken(w, ou, claims)
 
 	case "AddKey":
 		if req.Method != "POST" {
@@ -409,11 +425,19 @@ func (m *Manager) HandleCallback(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 		m.cfg.EventRecorder.Record("passkey addkey request")
-		var host string
-		if d, ok := m.nonces[req.Form.Get("nonce")]; ok {
-			host = d.host
+		origURL, err := m.cfg.TokenManager.ValidateURLToken(w, req, redirectToken)
+		if err != nil {
+			log.Printf("ERR ValidateURLToken: %v", err)
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
 		}
-		m.setAuthToken(w, host, claims)
+		ou, err := url.Parse(origURL)
+		if err != nil {
+			log.Printf("ERR url.Parse(%q): %v", origURL, err)
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		m.setAuthToken(w, ou, claims)
 
 	case "Switch":
 		if req.Method != "POST" {
@@ -426,9 +450,15 @@ func (m *Manager) HandleCallback(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 		m.cfg.OtherCookieManager.ClearCookies(w)
+		origURL, err := m.cfg.TokenManager.ValidateURLToken(w, req, redirectToken)
+		if err != nil {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
 		w.Header().Set("content-type", "application/json")
 		json.NewEncoder(w).Encode(map[string]string{
-			"result": "ok",
+			"result":   "ok",
+			"redirect": origURL,
 		})
 
 	case "JS":
@@ -684,7 +714,7 @@ func (m *Manager) deleteKey(email string, id Bytes) (retErr error) {
 	return commit(true, nil)
 }
 
-func (m *Manager) setAuthToken(w http.ResponseWriter, host string, claims map[string]any) {
+func (m *Manager) setAuthToken(w http.ResponseWriter, u *url.URL, claims map[string]any) {
 	subject, ok := claims["sub"].(string)
 	if !ok {
 		http.Error(w, "internal error", http.StatusInternalServerError)
@@ -700,14 +730,15 @@ func (m *Manager) setAuthToken(w http.ResponseWriter, host string, claims map[st
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
-	if err := m.cfg.CookieManager.SetAuthTokenCookie(w, subject, email, sid, host, claims); err != nil {
+	if err := m.cfg.CookieManager.SetAuthTokenCookie(w, subject, email, sid, u.Hostname(), claims); err != nil {
 		log.Printf("ERR SetAuthTokenCookie: %v", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 	w.Header().Set("content-type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{
-		"result": "ok",
+		"result":   "ok",
+		"redirect": u.String(),
 	})
 }
 

--- a/proxy/internal/passkeys/manager.go
+++ b/proxy/internal/passkeys/manager.go
@@ -301,17 +301,28 @@ func (m *Manager) HandleCallback(w http.ResponseWriter, req *http.Request) {
 
 	switch mode {
 	case "Login", "RegisterNewID", "RefreshID":
+		if originalURL == nil {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
 		data := struct {
 			Self         string
 			Token        string
 			Mode         string
 			Email        string
+			URL          string
+			DisplayURL   string
 			IsAllowed    bool
 			IsRegistered bool
 		}{
-			Self:  req.URL.Path,
-			Token: req.Form.Get("redirect"),
-			Mode:  mode,
+			Self:       req.URL.Path,
+			Token:      req.Form.Get("redirect"),
+			Mode:       mode,
+			URL:        originalURL.String(),
+			DisplayURL: originalURL.String(),
+		}
+		if len(data.DisplayURL) > 100 {
+			data.DisplayURL = data.DisplayURL[:97] + "..."
 		}
 		if mode == "RegisterNewID" || mode == "RefreshID" {
 			data.Email, _ = token.Claims.(jwt.MapClaims)["email"].(string)

--- a/proxy/internal/passkeys/webauthn.js
+++ b/proxy/internal/passkeys/webauthn.js
@@ -28,7 +28,7 @@ function registerPasskey(token) {
     throw new Error('Browser doesn\'t support WebAuthn');
   }
 
-  fetch('?get=AttestationOptions', {
+  fetch('?get=AttestationOptions'+(token?'&redirect='+token:''), {
     method: 'POST',
     headers: {
       'x-csrf-check': 1,
@@ -94,7 +94,7 @@ function loginWithPasskey(token) {
   if (!('PublicKeyCredential' in window)) {
     throw new Error('Browser doesn\'t support WebAuthn');
   }
-  fetch('?get=AssertionOptions', {
+  fetch('?get=AssertionOptions&redirect='+token, {
     method: 'POST',
     headers: {
       'x-csrf-check': 1,

--- a/proxy/internal/passkeys/webauthn.js
+++ b/proxy/internal/passkeys/webauthn.js
@@ -23,7 +23,7 @@
  * SOFTWARE.
  */
 
-function registerPasskey(redirectUrl, nonce) {
+function registerPasskey(token) {
   if (!('PublicKeyCredential' in window)) {
     throw new Error('Browser doesn\'t support WebAuthn');
   }
@@ -59,7 +59,7 @@ function registerPasskey(redirectUrl, nonce) {
       attestationObject: Array.from(new Uint8Array(pkc.response.attestationObject)),
       transports: pkc.response.getTransports(),
     });
-    return fetch('?get=AddKey'+(nonce?'&nonce='+nonce:''), {
+    return fetch('?get=AddKey'+(token?'&redirect='+token:''), {
       method: 'POST',
       headers: {
         'content-type': 'application/x-www-form-urlencoded',
@@ -77,8 +77,8 @@ function registerPasskey(redirectUrl, nonce) {
   .then(r => {
     if (r.result === 'ok') {
       console.log('Success');
-      if (redirectUrl) {
-        window.location = redirectUrl;
+      if (r.redirect) {
+        window.location = r.redirect;
       } else {
         window.location.reload();
       }
@@ -90,7 +90,7 @@ function registerPasskey(redirectUrl, nonce) {
   });
 }
 
-function loginWithPasskey(redirectUrl, nonce) {
+function loginWithPasskey(token) {
   if (!('PublicKeyCredential' in window)) {
     throw new Error('Browser doesn\'t support WebAuthn');
   }
@@ -121,7 +121,7 @@ function loginWithPasskey(redirectUrl, nonce) {
         signature: Array.from(new Uint8Array(pkc.response.signature)),
         userHandle: Array.from(new Uint8Array(pkc.response.userHandle)),
     });
-    return fetch('?get=Check&nonce='+nonce, {
+    return fetch('?get=Check&redirect='+token, {
       method: 'POST',
       headers: {
         'content-type': 'application/x-www-form-urlencoded',
@@ -140,8 +140,8 @@ function loginWithPasskey(redirectUrl, nonce) {
   .then(r => {
     if (r.result === 'ok') {
       console.log('Success');
-      if (redirectUrl) {
-        window.location = redirectUrl;
+      if (r.redirect) {
+        window.location = r.redirect;
       } else {
         window.location.reload();
       }
@@ -188,8 +188,8 @@ function deleteKey(id) {
 }
 
 
-function switchAccount(redirectUrl) {
-  fetch('?get=Switch', {
+function switchAccount(token) {
+  fetch('?get=Switch&redirect='+token, {
     method: 'POST',
     headers: {
       'x-csrf-check': 1,
@@ -204,8 +204,8 @@ function switchAccount(redirectUrl) {
   .then(r => {
     if (r.result === 'ok') {
       console.log('Success');
-      if (redirectUrl) {
-        window.location = redirectUrl;
+      if (r.redirect) {
+        window.location = r.redirect;
       } else {
         window.location.reload();
       }

--- a/proxy/internal/tokenmanager/urltoken.go
+++ b/proxy/internal/tokenmanager/urltoken.go
@@ -55,7 +55,7 @@ func sessionID(w http.ResponseWriter, req *http.Request) string {
 		Value:    sid,
 		Path:     "/",
 		Expires:  time.Now().Add(30 * 24 * time.Hour),
-		SameSite: http.SameSiteStrictMode,
+		SameSite: http.SameSiteLaxMode,
 		Secure:   true,
 		HttpOnly: true,
 	})

--- a/proxy/internal/tokenmanager/urltoken.go
+++ b/proxy/internal/tokenmanager/urltoken.go
@@ -38,12 +38,12 @@ import (
 )
 
 const (
-	sessionIDCookieName = "TLSPROXYSID"
+	SessionIDCookieName = "TLSPROXYSID"
 )
 
 func sessionID(w http.ResponseWriter, req *http.Request) string {
 	var sid string
-	if cookie, err := req.Cookie(sessionIDCookieName); err == nil {
+	if cookie, err := req.Cookie(SessionIDCookieName); err == nil {
 		sid = cookie.Value
 	} else {
 		var buf [16]byte
@@ -51,7 +51,7 @@ func sessionID(w http.ResponseWriter, req *http.Request) string {
 		sid = hex.EncodeToString(buf[:])
 	}
 	http.SetCookie(w, &http.Cookie{
-		Name:     sessionIDCookieName,
+		Name:     SessionIDCookieName,
 		Value:    sid,
 		Path:     "/",
 		Expires:  time.Now().Add(30 * 24 * time.Hour),

--- a/proxy/internal/tokenmanager/urltoken.go
+++ b/proxy/internal/tokenmanager/urltoken.go
@@ -1,0 +1,98 @@
+// MIT License
+//
+// Copyright (c) 2024 TTBT Enterprises LLC
+// Copyright (c) 2024 Robin Thellend <rthellend@rthellend.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package tokenmanager
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"time"
+
+	jwt "github.com/golang-jwt/jwt/v5"
+	"golang.org/x/net/idna"
+)
+
+const (
+	sessionIDCookieName = "TLSPROXYSID"
+)
+
+func sessionID(w http.ResponseWriter, req *http.Request) string {
+	var sid string
+	if cookie, err := req.Cookie(sessionIDCookieName); err == nil {
+		sid = cookie.Value
+	} else {
+		var buf [16]byte
+		io.ReadFull(rand.Reader, buf[:])
+		sid = hex.EncodeToString(buf[:])
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionIDCookieName,
+		Value:    sid,
+		Path:     "/",
+		Expires:  time.Now().Add(30 * 24 * time.Hour),
+		SameSite: http.SameSiteStrictMode,
+		Secure:   true,
+		HttpOnly: true,
+	})
+	return sid
+}
+
+func (tm *TokenManager) URLToken(w http.ResponseWriter, req *http.Request, u *url.URL) (string, string, error) {
+	sid := sessionID(w, req)
+	realHost := u.Host
+	if h, err := idna.Lookup.ToUnicode(u.Hostname()); err == nil {
+		u.Host = h
+	}
+	displayURL := u.String()
+	u.Host = realHost
+	token, err := tm.CreateToken(jwt.MapClaims{
+		"url": u.String(),
+		"sid": sid,
+	}, "EdDSA")
+	return token, displayURL, err
+}
+
+func (tm *TokenManager) ValidateURLToken(w http.ResponseWriter, req *http.Request, token string) (string, error) {
+	tok, err := tm.ValidateToken(token)
+	if err != nil {
+		return "", err
+	}
+	c, ok := tok.Claims.(jwt.MapClaims)
+	if !ok {
+		return "", errors.New("invalid token")
+	}
+	if sid := sessionID(w, req); sid != c["sid"] {
+		log.Printf("ERR session ID mismatch %q != %q", sid, c["sid"])
+		return "", errors.New("invalid token")
+	}
+	url, ok := c["url"].(string)
+	if !ok {
+		return "", errors.New("invalid token")
+	}
+	return url, nil
+}

--- a/proxy/internal/tokenmanager/urltoken_test.go
+++ b/proxy/internal/tokenmanager/urltoken_test.go
@@ -64,7 +64,7 @@ func TestURLToken(t *testing.T) {
 	if err != nil {
 		t.Errorf("ValidateURLToken err = %v", err)
 	}
-	if got, want := u, "https://example.com/foo/bar"; got != want {
+	if got, want := u.String(), "https://example.com/foo/bar"; got != want {
 		t.Errorf("url = %q, want %q", got, want)
 	}
 }

--- a/proxy/internal/tokenmanager/urltoken_test.go
+++ b/proxy/internal/tokenmanager/urltoken_test.go
@@ -1,0 +1,70 @@
+// MIT License
+//
+// Copyright (c) 2024 TTBT Enterprises LLC
+// Copyright (c) 2024 Robin Thellend <rthellend@rthellend.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package tokenmanager
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/c2FmZQ/storage"
+	"github.com/c2FmZQ/storage/crypto"
+)
+
+func TestURLToken(t *testing.T) {
+	dir := t.TempDir()
+	mk, err := crypto.CreateAESMasterKeyForTest()
+	if err != nil {
+		t.Fatalf("crypto.CreateMasterKey: %v", err)
+	}
+	store := storage.New(dir, mk)
+	tm, err := New(store)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "https://example.com/foo/bar", nil)
+	w := httptest.NewRecorder()
+	tok, displayURL, err := tm.URLToken(w, req, req.URL)
+	if err != nil {
+		t.Errorf("URLToken() err = %v", err)
+	}
+	if got, want := displayURL, "https://example.com/foo/bar"; got != want {
+		t.Errorf("displayURL = %q, want %q", got, want)
+	}
+
+	// Wrong session id
+	if _, err := tm.ValidateURLToken(w, req, tok); err == nil {
+		t.Fatal("ValidateURLToken should fail")
+	}
+
+	// Correct session id
+	req.Header.Set("cookie", w.Header().Get("set-cookie"))
+	u, err := tm.ValidateURLToken(w, req, tok)
+	if err != nil {
+		t.Errorf("ValidateURLToken err = %v", err)
+	}
+	if got, want := u, "https://example.com/foo/bar"; got != want {
+		t.Errorf("url = %q, want %q", got, want)
+	}
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -345,6 +345,7 @@ func (p *Proxy) Reconfigure(cfg *Config) error {
 			EventRecorder:      er,
 			CookieManager:      cm,
 			OtherCookieManager: other.cm,
+			TokenManager:       p.tokenManager,
 			ClaimsFromCtx:      claimsFromCtx,
 		}
 		provider, err := passkeys.NewManager(cfg)

--- a/proxy/sso_test.go
+++ b/proxy/sso_test.go
@@ -356,7 +356,7 @@ func TestSSOEnforcePasskey(t *testing.T) {
 	auth.SetOrigin("https://" + host)
 
 	// Get the attestation options.
-	code, body, _ = get("https://"+host+"/passkey?get=AttestationOptions", nil, []byte{})
+	code, body, _ = get("https://"+host+"/passkey?get=AttestationOptions&redirect="+token, nil, []byte{})
 	if got, want := code, 200; got != want {
 		t.Errorf("Code = %v, want %v", got, want)
 	}
@@ -424,7 +424,7 @@ func TestSSOEnforcePasskey(t *testing.T) {
 	t.Logf("TOKEN: %s", token)
 
 	// Get the assertion options.
-	code, body, _ = get("https://"+host+"/passkey?get=AssertionOptions", nil, []byte{})
+	code, body, _ = get("https://"+host+"/passkey?get=AssertionOptions&redirect="+token, nil, []byte{})
 	if got, want := code, 200; got != want {
 		t.Errorf("Code = %v, want %v", got, want)
 	}


### PR DESCRIPTION
### Description

Use signed tokens that don't expire on the passkey login page. This improves the user experience when the browser remains on the login page for a long time.

### Type of change

* [ ] New feature
* [x] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [x] Cleanup / refactoring
* [ ] Other (please explain)


### How is this change tested ?

* [x] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
