### PR TITLE
Remove unnecessary locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # TLSPROXY Release Notes
 
 * Improve user experience with the passkey login screen.
+* Fix small accounting bug in ingress metrics.
 
 ## v0.4.3
 

--- a/proxy/internal/netw/netw.go
+++ b/proxy/internal/netw/netw.go
@@ -200,13 +200,14 @@ func (c *Conn) Read(b []byte) (int, error) {
 			return 0, err
 		}
 	}
+	var n int
+	var err error
 	if len(c.peekBuf) > 0 {
-		n := copy(b, c.peekBuf)
+		n = copy(b, c.peekBuf)
 		c.peekBuf = c.peekBuf[n:]
-		c.bytesReceived.Incr(int64(n))
-		return n, nil
+	} else {
+		n, err = c.Conn.Read(b)
 	}
-	n, err := c.Conn.Read(b)
 	c.bytesReceived.Incr(int64(n))
 	c.upBytesReceived.Incr(int64(n))
 	return n, err

--- a/proxy/internal/netw/netw.go
+++ b/proxy/internal/netw/netw.go
@@ -88,11 +88,11 @@ type Conn struct {
 	upBytesSent     *counter.Counter
 	upBytesReceived *counter.Counter
 
+	peekBuf []byte
+
 	mu          sync.Mutex
 	onClose     func()
 	annotations map[string]any
-
-	peekBuf []byte
 }
 
 func (c *Conn) StreamID() int64 {
@@ -177,8 +177,6 @@ func (c *Conn) OnClose(f func()) {
 }
 
 func (c *Conn) Peek(b []byte) (int, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	want := len(b)
 	have := len(c.peekBuf)
 	if want > have {
@@ -202,15 +200,12 @@ func (c *Conn) Read(b []byte) (int, error) {
 			return 0, err
 		}
 	}
-	c.mu.Lock()
 	if len(c.peekBuf) > 0 {
 		n := copy(b, c.peekBuf)
 		c.peekBuf = c.peekBuf[n:]
 		c.bytesReceived.Incr(int64(n))
-		c.mu.Unlock()
 		return n, nil
 	}
-	c.mu.Unlock()
 	n, err := c.Conn.Read(b)
 	c.bytesReceived.Incr(int64(n))
 	c.upBytesReceived.Incr(int64(n))


### PR DESCRIPTION
### Description

Remove unnecessary locks. Read and Peek are never called concurrently.
Fix small accounting bug.

### Type of change

* [ ] New feature
* [ ] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [x] Cleanup / refactoring
* [ ] Other (please explain)


### How is this change tested ?

* [x] Unit tests
* [ ] Manual tests (explain)
* [x] Tests are not needed
