### PR TITLE
Apply forward rate limit to http requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Improve user experience with the passkey login screen.
 * Fix small accounting bug in ingress metrics.
+* Apply the forward rate limit to http requests. Before, the rate limit was only applied to incoming connections.
 
 ## v0.4.3
 

--- a/proxy/backend-http.go
+++ b/proxy/backend-http.go
@@ -170,15 +170,12 @@ func (be *Backend) reverseProxy() http.Handler {
 		// Apply the forward rate limit. The first request was already
 		// counted when the connection was established.
 		if conn, ok := ctx.Value(connCtxKey).(annotatedConnection); ok {
-			rc := conn.Annotation(requestCountKey, (*int)(nil)).(*int)
-			if rc == nil {
-				rc = new(int)
-				conn.SetAnnotation(requestCountKey, rc)
+			if !conn.Annotation(requestFlagKey, false).(bool) {
+				conn.SetAnnotation(requestFlagKey, true)
 			} else if err := be.connLimit.Wait(ctx); err != nil {
 				http.Error(w, "ctx", http.StatusInternalServerError)
 				return
 			}
-			*rc = *rc + 1
 		}
 		reverseProxy.ServeHTTP(w, req.WithContext(ctx))
 	})

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -267,7 +267,8 @@ type Backend struct {
 	// TLS certificate. See https://pkg.go.dev/crypto/tls#Config
 	InsecureSkipVerify bool `yaml:"insecureSkipVerify,omitempty"`
 	// ForwardRateLimit specifies how fast requests can be forwarded to the
-	// backend servers. The default value is 5 requests per second.
+	// backend servers. It applies to forwarding connections, and to
+	// forwarding HTTP requests. The default value is 5 requests per second.
 	ForwardRateLimit int `yaml:"forwardRateLimit"`
 	// ForwardServerName is the ServerName to send in the TLS handshake with
 	// the backend server. It is also used to verify the server's identify.

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -81,7 +81,7 @@ const (
 	internalConnKey  = "ic"
 	reportEndKey     = "re"
 	backendKey       = "be"
-	requestCountKey  = "rc"
+	requestFlagKey   = "rf"
 
 	tlsBadCertificate      = tls.AlertError(0x2a)
 	tlsCertificateRevoked  = tls.AlertError(0x2c)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -81,6 +81,7 @@ const (
 	internalConnKey  = "ic"
 	reportEndKey     = "re"
 	backendKey       = "be"
+	requestCountKey  = "rc"
 
 	tlsBadCertificate      = tls.AlertError(0x2a)
 	tlsCertificateRevoked  = tls.AlertError(0x2c)


### PR DESCRIPTION
### Description

Before, the rate limit was only applied to incoming connections. Now, it is still applied to incoming connections, but in the case of forwarded HTTP requests, it is also applied to successive HTTP requests on the same keep-alive connection.

### Type of change

* [ ] New feature
* [ ] Feature improvement
* [x] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)

### How is this change tested ?

* [ ] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
