### PR TITLE
Adjustments for proxyproto LocalAddr

### DIFF
--- a/proxy/backend-http.go
+++ b/proxy/backend-http.go
@@ -141,7 +141,7 @@ func (be *Backend) reverseProxy() http.Handler {
 		ctx = context.WithValue(ctx, ctxURLKey, req.URL.String())
 
 		// Detect forwarding loops using the via headers.
-		me := req.Context().Value(connCtxKey).(net.Conn).LocalAddr().String()
+		me := localNetConn(req.Context().Value(connCtxKey).(net.Conn)).LocalAddr().String()
 		hops := commaRE.Split(req.Header.Get(viaHeader), -1)
 		for _, via := range hops {
 			if _, via, _ = strings.Cut(via, " "); via == me {

--- a/proxy/metrics-template.html
+++ b/proxy/metrics-template.html
@@ -203,7 +203,7 @@ function selectTab(target) {
 {{- range .Connections }}
   <div>
     <div style="margin-left: 2rem; padding-top: 0.5rem; display: grid; grid-template-columns: auto auto; justify-items: left; width: fit-content; column-gap: 1rem;">
-      <div>{{.SourceAddr}} {{.Type}}</div>
+      <div>{{.SourceAddr}}{{ if ne .ViaAddr "" }} &lt;=&gt; {{.ViaAddr}}{{ end }} {{.Type}}</div>
       <div>&lt;=&gt; {{.ServerName}} {{.Mode}} {{.Proto}}</div>
   {{- range .Destinations }}
       <div>&nbsp;</div>

--- a/proxy/metrics.go
+++ b/proxy/metrics.go
@@ -141,6 +141,7 @@ func (p *Proxy) metricsHandler(w http.ResponseWriter, req *http.Request) {
 	}
 	type connection struct {
 		SourceAddr   string
+		ViaAddr      string
 		Type         string
 		ServerName   string
 		Mode         string
@@ -280,15 +281,15 @@ func (p *Proxy) metricsHandler(w http.ResponseWriter, req *http.Request) {
 		startTime := c.Annotation(startTimeKey, time.Time{}).(time.Time)
 		totalTime := time.Since(startTime)
 		remote := c.RemoteAddr().Network() + ":" + c.RemoteAddr().String()
-		if isProxyProtoConn(c) {
-			remote += "*"
-		}
 
 		connection := connection{
 			SourceAddr: remote,
 			ServerName: idnaToUnicode(connServerName(c)),
 			Mode:       connMode(c),
 			Proto:      connProto(c),
+		}
+		if isProxyProtoConn(c) {
+			connection.ViaAddr = c.LocalAddr().Network() + ":" + c.LocalAddr().String()
 		}
 		var streams []*netw.QUICStream
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1363,7 +1363,8 @@ func formatConnDesc(c net.Conn, ids ...string) string {
 	}
 	buf.WriteString(c.RemoteAddr().Network() + ":" + c.RemoteAddr().String())
 	if isProxyProtoConn(c) {
-		buf.WriteString("*")
+		buf.WriteString(" ➔ ")
+		buf.WriteString(c.LocalAddr().Network() + ":" + c.LocalAddr().String())
 	}
 	if serverName != "" {
 		buf.WriteString(" ➔ ")

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1362,6 +1362,9 @@ func formatConnDesc(c net.Conn, ids ...string) string {
 		buf.WriteString("[" + strings.Join(identities, "|") + "] ")
 	}
 	buf.WriteString(c.RemoteAddr().Network() + ":" + c.RemoteAddr().String())
+	if isProxyProtoConn(c) {
+		buf.WriteString("*")
+	}
 	if serverName != "" {
 		buf.WriteString(" ➔ ")
 		buf.WriteString(idnaToUnicode(serverName))
@@ -1376,6 +1379,31 @@ func formatConnDesc(c net.Conn, ids ...string) string {
 		}
 	}
 	return buf.String()
+}
+
+func isProxyProtoConn(c net.Conn) bool {
+	switch cc := c.(type) {
+	case *tls.Conn:
+		return isProxyProtoConn(cc.NetConn())
+	case *netw.Conn:
+		_, ok := cc.Conn.(*proxyproto.Conn)
+		return ok
+	default:
+		return false
+	}
+}
+
+func localNetConn(c net.Conn) net.Conn {
+	switch cc := c.(type) {
+	case *tls.Conn:
+		return localNetConn(cc.NetConn())
+	case *netw.Conn:
+		return localNetConn(cc.Conn)
+	case *proxyproto.Conn:
+		return cc.Raw()
+	default:
+		return cc
+	}
 }
 
 func setKeepAlive(conn net.Conn) {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1387,8 +1387,9 @@ func isProxyProtoConn(c net.Conn) bool {
 	case *tls.Conn:
 		return isProxyProtoConn(cc.NetConn())
 	case *netw.Conn:
-		_, ok := cc.Conn.(*proxyproto.Conn)
-		return ok
+		return isProxyProtoConn(cc.Conn)
+	case *proxyproto.Conn:
+		return true
 	default:
 		return false
 	}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1207,6 +1207,12 @@ func newProxyProtocolServer(t *testing.T, ctx context.Context, name string, ca t
 			t.Logf("[%s] Received connection from %s", name, conn.RemoteAddr())
 			f, _ := conn.(*proxyproto.Conn).ProxyHeader().Format()
 			t.Logf("[%s] PROXY HEADER: %q", name, f)
+			if got, want := isProxyProtoConn(conn), true; got != want {
+				t.Errorf("isProxyProtoConn() = %v, want %v", got, want)
+			}
+			if got, want := localNetConn(conn), conn.(*proxyproto.Conn).Raw(); got != want {
+				t.Errorf("localNetConn() = %v, want %v", got, want)
+			}
 			go func(c net.Conn) {
 				fmt.Fprintf(c, "Hello %s from %s\n", c.RemoteAddr(), name)
 				c.Close()


### PR DESCRIPTION
### Description

The proxyproto library `Conn`'s `LocalAddr()` returns an address on a remote server. So, we need to be careful when `LocalAddr()` is used. In some cases, we need the address of the local socket.

### Type of change

* [ ] New feature
* [ ] Feature improvement
* [x] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)

### How is this change tested ?

* [x] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
