### PR TITLE
Use cached conn only with same client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # TLSPROXY Release Notes
 
+* Prevent backend connections from being re-used when PROXY proto is enabled.
+
 ## v0.5.0
 
 * Add support for the PROXY protocol for incoming connections. See the `AcceptProxyHeaderFrom` config option.

--- a/proxy/backend-http.go
+++ b/proxy/backend-http.go
@@ -160,20 +160,27 @@ func (be *Backend) reverseProxy() http.Handler {
 		// dial(), but we need to set req.URL.Host to a unique value
 		// so that the http client will not re-use connections with
 		// other addresses.
-		h := sha256.Sum256([]byte(hostname))
-		hh := hex.EncodeToString(h[:])
-		req.URL.Host = hh
+		override := ""
+		proxyProtoVersion := be.proxyProtocolVersion
 	L:
 		for i, po := range be.PathOverrides {
 			for _, prefix := range po.Paths {
 				if !strings.HasPrefix(req.URL.Path, prefix) {
 					continue
 				}
-				req.URL.Host = fmt.Sprintf("%s-%d", hh, i)
 				ctx = context.WithValue(ctx, ctxOverrideIDKey, i)
+				override = fmt.Sprintf(";%d", i)
+				proxyProtoVersion = po.proxyProtocolVersion
 				break L
 			}
 		}
+		hostKey := hostname + override
+		if proxyProtoVersion > 0 {
+			cc := req.Context().Value(connCtxKey).(net.Conn)
+			hostKey += ";" + cc.RemoteAddr().String() + ";" + cc.LocalAddr().String()
+		}
+		h := sha256.Sum256([]byte(hostKey))
+		req.URL.Host = hex.EncodeToString(h[:])
 
 		// Apply the forward rate limit. The first request was already
 		// counted when the connection was established.
@@ -270,8 +277,8 @@ func (be *Backend) reverseProxyTransport() http.RoundTripper {
 		DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			return be.dial(ctx)
 		},
-		MaxIdleConns:          100,
-		IdleConnTimeout:       30 * time.Second,
+		MaxIdleConns:          10,
+		IdleConnTimeout:       10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	}
 	h2 := &http2.Transport{
@@ -280,7 +287,7 @@ func (be *Backend) reverseProxyTransport() http.RoundTripper {
 		},
 		DisableCompression: true,
 		AllowHTTP:          true,
-		ReadIdleTimeout:    30 * time.Second,
+		ReadIdleTimeout:    10 * time.Second,
 		WriteByteTimeout:   30 * time.Second,
 		CountError: func(errType string) {
 			be.recordEvent("http2 client error: " + errType)

--- a/proxy/backend.go
+++ b/proxy/backend.go
@@ -162,6 +162,9 @@ func (be *Backend) dial(ctx context.Context, protos ...string) (net.Conn, error)
 		if mode == ModeTLS || mode == ModeHTTPS {
 			c = tls.Client(c, tc)
 		}
+		if cc, ok := ctx.Value(connCtxKey).(net.Conn); ok {
+			annotatedConn(cc).SetAnnotation(internalConnKey, c)
+		}
 		return c, nil
 	}
 }

--- a/proxy/metrics.go
+++ b/proxy/metrics.go
@@ -321,9 +321,6 @@ func (p *Proxy) metricsHandler(w http.ResponseWriter, req *http.Request) {
 			if addr == "" {
 				addr = stream.BridgeAddr()
 			}
-			if addr == "" {
-				addr = "local"
-			}
 			streamID := stream.StreamID()
 			var dir string
 			// bit 0: 0 -> client initiated, 1 -> server initiated

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1237,9 +1237,7 @@ func (p *Proxy) handleTLSConnection(extConn *tls.Conn) {
 	}
 	defer intConn.Close()
 	setKeepAlive(intConn)
-
 	netwConn(extConn).SetAnnotation(dialDoneKey, time.Now())
-	netwConn(extConn).SetAnnotation(internalConnKey, intConn)
 
 	desc := formatConnDesc(netwConn(extConn))
 	log.Printf("CON %s", desc)
@@ -1280,7 +1278,6 @@ func (p *Proxy) handleTLSPassthroughConnection(extConn net.Conn) {
 	setKeepAlive(intConn)
 
 	netwConn(extConn).SetAnnotation(dialDoneKey, time.Now())
-	netwConn(extConn).SetAnnotation(internalConnKey, intConn)
 
 	desc := formatConnDesc(netwConn(extConn))
 	log.Printf("CON %s", desc)


### PR DESCRIPTION
### Description

When PROXY protocol is enabled, prevent cached connections from being re·used by other remote clients.

### Type of change

* [ ] New feature
* [ ] Feature improvement
* [X] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)


### How is this change tested ?

* [ ] Unit tests
* [ ] Manual tests (explain)
* [ ] Tests are not needed
