### PR TITLE
Enable quic datagrams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # TLSPROXY Release Notes
 
+* Add support for QUIC datagrams.
+
 ## v0.5.2
 
 * Report outbound connections on the metrics page.

--- a/proxy/internal/netw/quic.go
+++ b/proxy/internal/netw/quic.go
@@ -44,7 +44,8 @@ import (
 )
 
 var quicConfig = &quic.Config{
-	MaxIdleTimeout: 30 * time.Second,
+	MaxIdleTimeout:  30 * time.Second,
+	EnableDatagrams: true,
 }
 
 // NewQUIC returns a wrapper around a quic.Transport to keep track of metrics

--- a/proxy/quic.go
+++ b/proxy/quic.go
@@ -291,7 +291,7 @@ func (p *Proxy) handleQUICConnection(qc *netw.QUICConn) {
 			for {
 				b, err := qc.ReceiveDatagram(ctx)
 				if err != nil {
-					reportErr(err, "ReceiveDatagram->")
+					reportErr(err, "->ReceiveDatagram")
 					return
 				}
 				if err := beConn.SendDatagram(b); err != nil {
@@ -309,7 +309,7 @@ func (p *Proxy) handleQUICConnection(qc *netw.QUICConn) {
 					return
 				}
 				if err := qc.SendDatagram(b); err != nil {
-					reportErr(err, "SendDatagram<-")
+					reportErr(err, "<-SendDatagram")
 				}
 			}
 		}()

--- a/proxy/quic_test.go
+++ b/proxy/quic_test.go
@@ -282,15 +282,11 @@ func quicDatagram(name, addr, msg string, rootCA *certmanager.CertManager, proto
 	if err != nil {
 		return "", err
 	}
-	done := make(chan struct{})
-	defer close(done)
 	go func() {
 		for {
 			conn.SendDatagram([]byte(msg))
 			select {
 			case <-ctx.Done():
-				return
-			case <-done:
 				return
 			case <-time.After(50 * time.Millisecond):
 			}


### PR DESCRIPTION
### Description

Enable datagrams for QUIC and HTTP/3 connections.

### Type of change

* [ ] New feature
* [x] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)


### How is this change tested ?

* [x] Unit tests
* [ ] Manual tests (explain)
* [ ] Tests are not needed
