### PR TITLE
Fix for websocket connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # TLSPROXY Release Notes
 
+* Fix WebSocket connections when `backendProto` is set to something other than `http/1.1`.
+
 ## v0.6.0
 
 * Starting with v0.6.0, tlsproxy is built with QUIC & HTTP/3 support by default. Binaries without QUIC can still be built with `-tags noquic`.

--- a/proxy/backend-http.go
+++ b/proxy/backend-http.go
@@ -311,6 +311,14 @@ func (be *Backend) reverseProxyTransport() http.RoundTripper {
 		if proto == "" && req.TLS != nil && req.TLS.NegotiatedProtocol != "" {
 			proto = req.TLS.NegotiatedProtocol
 		}
+		if req.ProtoMajor == 1 {
+			for _, hdr := range strings.Split(req.Header.Get("connection"), ",") {
+				// Connection upgrades, e.g. websocket, must use http/1.1.
+				if strings.ToLower(strings.TrimSpace(hdr)) == "upgrade" {
+					proto = "http/1.1"
+				}
+			}
+		}
 		if proto == "h3" && h3 != nil {
 			return h3.RoundTrip(req)
 		}


### PR DESCRIPTION
### Description

HTTP protocol upgrades are only valid with HTTP/1.1. Disregard the value of `backendProto` when `upgrade` is present in the `connection` header.

### Type of change

* [ ] New feature
* [ ] Feature improvement
* [x] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)

### How is this change tested ?

* [ ] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
