### PR TITLE
Fix bug that prevents admin from revoking certs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # TLSPROXY Release Notes
 
 * Update go: 1.22.0
-* Log HTTP protocol upgrades
-* Add mutex profile to metrics page
+* Log HTTP protocol upgrades.
+* Add mutex profile to metrics page.
+* Fix bug that prevented PKI admins from revoking certificates.
 
 ## v0.6.1
 

--- a/proxy/internal/pki/http.go
+++ b/proxy/internal/pki/http.go
@@ -439,7 +439,7 @@ func (m *PKIManager) handleRevokeCert(w http.ResponseWriter, req *http.Request, 
 		http.Error(w, "invalid request", http.StatusBadRequest)
 		return
 	}
-	if isAdmin || !slices.Contains(c.EmailAddresses, email) {
+	if !isAdmin && !slices.Contains(c.EmailAddresses, email) {
 		w.Header().Set("content-type", "application/json")
 		json.NewEncoder(w).Encode(map[string]string{
 			"result": "permission denied",


### PR DESCRIPTION
### Description

Fix bug that prevents admin from revoking certs.

### Type of change

* [ ] New feature
* [ ] Feature improvement
* [x] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)

### How is this change tested ?

* [ ] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
