### PR TITLE
Improve heap & lock profiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 * Update go: 1.22.0
 * Log HTTP protocol upgrades.
-* Add mutex profile to metrics page.
 * Fix bug that prevented PKI admins from revoking certificates.
+* Improve heap & lock profiling.
+* Reduce lock contention.
 
 ## v0.6.1
 

--- a/proxy/metrics-template.html
+++ b/proxy/metrics-template.html
@@ -286,7 +286,7 @@ Backend[{{$i}}]: {{.Mode}} {{.ALPNProtos}} {{.BackendProto}} {{.SSO}}
 </div>
 
 <div id="panel-memory">
-<h2>Memory profile</h2>
+<h2>Heap allocations (> 100 KiB)</h2>
   <div class="table col3">
     <div class="hdr">
       <div>Size</div>
@@ -304,7 +304,7 @@ Backend[{{$i}}]: {{.Mode}} {{.ALPNProtos}} {{.BackendProto}} {{.SSO}}
 </div>
 
 <div id="panel-mutex">
-<h2>Mutex profile</h2>
+<h2>Lock contention</h2>
   <div class="table col3">
     <div class="hdr">
       <div>Cycles</div>

--- a/proxy/metrics-template.html
+++ b/proxy/metrics-template.html
@@ -304,7 +304,7 @@ Backend[{{$i}}]: {{.Mode}} {{.ALPNProtos}} {{.BackendProto}} {{.SSO}}
 </div>
 
 <div id="panel-mutex">
-<h2>Lock contention</h2>
+<h2>Lock contention (> 1M Cycles)</h2>
   <div class="table col3">
     <div class="hdr">
       <div>Cycles</div>

--- a/proxy/metrics.go
+++ b/proxy/metrics.go
@@ -484,6 +484,9 @@ func (p *Proxy) metricsHandler(w http.ResponseWriter, req *http.Request) {
 			}
 			return items[i].Size > items[j].Size
 		})
+		if len(items) > 25 {
+			items = items[:25]
+		}
 		data.Memory = items
 	} else {
 		log.Printf("ERR MemoryProfile n=%d", n)
@@ -506,12 +509,18 @@ func (p *Proxy) metricsHandler(w http.ResponseWriter, req *http.Request) {
 		for _, item := range itemMap {
 			items = append(items, item)
 		}
+		items = slices.DeleteFunc(items, func(e mutexProf) bool {
+			return e.Cycles < 1000000
+		})
 		sort.Slice(items, func(i, j int) bool {
 			if items[i].Cycles == items[j].Cycles {
 				return items[i].Func < items[j].Func
 			}
 			return items[i].Cycles > items[j].Cycles
 		})
+		if len(items) > 25 {
+			items = items[:25]
+		}
 		data.Mutex = items
 	} else {
 		log.Printf("ERR MutexProfile n=%d", n)

--- a/proxy/quic.go
+++ b/proxy/quic.go
@@ -73,8 +73,8 @@ func (p *Proxy) startQUIC(ctx context.Context) error {
 	tc := p.baseTLSConfig()
 	tc.MinVersion = tls.VersionTLS13
 	tc.GetConfigForClient = func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
-		p.mu.Lock()
-		defer p.mu.Unlock()
+		p.mu.RLock()
+		defer p.mu.RUnlock()
 		for _, proto := range hello.SupportedProtos {
 			if be, ok := p.backends[beKey{serverName: hello.ServerName, proto: proto}]; ok && be.Mode != ModeTLSPassthrough {
 				return be.tlsConfigQUIC, nil


### PR DESCRIPTION
### Description

Display all heap allocations that add up to at least 100 KiB.
Display all lock contention that adds up to at least 1 million cycles.
Reduce lock contention.

### Type of change

* [ ] New feature
* [x] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)

### How is this change tested ?

* [ ] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
