### PR TITLE
Add --quiet flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # TLSPROXY Release Notes
 
+* Add `--quiet` flag. When set (or the `TLSPROXY_QUIET` env variable is `true`), logging is turned off after tlsproxy starts.
+
 ## v0.6.4
 
 * Update go: 1.22.1

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ package main
 import (
 	"context"
 	"flag"
+	"io"
 	"log"
 	"os"
 	"os/signal"
@@ -55,6 +56,7 @@ func main() {
 	shutdownGraceFlag := flag.Duration("shutdown-grace-period", time.Minute, "The shutdown grace period.")
 	testFlag := flag.Bool("use-ephemeral-certificate-manager", false, "Use an ephemeral certificate manager. This is for testing purposes only.")
 	stdoutFlag := flag.Bool("stdout", false, "Log to STDOUT.")
+	quietFlag := flag.Bool("quiet", os.Getenv("TLSPROXY_QUIET") == "true", "Turn off logging after start-up.")
 	flag.Parse()
 
 	if *versionFlag {
@@ -96,6 +98,9 @@ func main() {
 	}
 	if err := p.Start(ctx); err != nil {
 		log.Fatal(err)
+	}
+	if *quietFlag {
+		log.SetOutput(io.Discard)
 	}
 	go configLoop(ctx, p, *configFile)
 


### PR DESCRIPTION
### Description

When `--quiet` is set (or the `TLSPROXY_QUIET` env variable is `true`), logging is turned off after tlsproxy starts.

### Type of change

* [x] New feature
* [ ] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)

### How is this change tested ?

* [ ] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
