### PR TITLE
Serve static content from local filesystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## next
 
+### :star2: New features
+
+* Serve static files from a local filesystem when `documentRoot:` is set.
+
 ## v0.7.2
 
 ### :wrench: Misc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.22.2-alpine3.19 AS build
 MAINTAINER info@c2fmzq.org
 RUN apk update && apk upgrade
-RUN apk add ca-certificates
+RUN apk add ca-certificates bluefish
 
 ADD . /app/go/src/tlsproxy
 WORKDIR /app/go/src/tlsproxy
@@ -13,6 +13,7 @@ FROM scratch
 WORKDIR /
 COPY --from=build /etc/ssl /etc/ssl/
 COPY --from=build /usr/share/ca-certificates /usr/share/ca-certificates/
+COPY --from=build /usr/share/mime/globs2 /usr/share/mime/
 COPY --from=build /go/bin/tlsproxy /bin/
 
 EXPOSE 10080 10443 10443/udp

--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@
 
 TLSPROXY is primarily a [TLS termination proxy](https://en.wikipedia.org/wiki/TLS_termination_proxy) that uses Let's Encrypt to provide TLS encryption for any number of TCP or HTTP servers, and any number of server names concurrently on the same port.
 
-Its functionality is similar to an [stunnel](https://www.stunnel.org/) server, but without the need to configure and run [certbot](https://certbot.eff.org/) separately.
-
-TLSPROXY can also be used as a [Reverse Proxy](https://en.wikipedia.org/wiki/Reverse_proxy) for HTTP(S) services, and optionally control access to these services with user authentication and authorization.
+TLSPROXY can also be used as a simple [Web server](https://en.wikipedia.org/wiki/Web_server), or a [Reverse Proxy](https://en.wikipedia.org/wiki/Reverse_proxy) for HTTP(S) services, and optionally control access to these services with user authentication and authorization.
 
 Overview of features:
 
@@ -18,6 +16,7 @@ Overview of features:
 * [x] Terminate _TCP_ connections, and forward the TLS connection to any TLS server (passthrough). The proxy doesn't see the plaintext.
 * [x] Terminate [QUIC](https://github.com/c2FmZQ/tlsproxy/blob/main/docs/QUIC.md) connections, and forward the data to any QUIC or TLS/TCP server.
 * [x] Terminate HTTPS connections, and forward the requests to HTTP or HTTPS servers (http/1.1, http/2, http/3).
+* [x] Serve static files from a local filesystem.
 * [x] Support for the [PROXY protocol](https://github.com/haproxy/haproxy/blob/master/doc/proxy-protocol.txt) defined by HAProxy. (not on QUIC or HTTP/3 backends)
 * [x] TLS client authentication & authorization (when the proxy terminates the TLS connections).
 * [x] Built-in Certificate Authority for managing client and backend server TLS certificates.
@@ -147,6 +146,14 @@ backends:
   mode: tlspassthrough
   addresses:
   - 192.168.5.66:8443
+
+# When documentRoot is set, static content is served from that directory.
+# (The addresses field must be empty)
+backends:
+- serverNames: 
+  - static.example.com
+  mode: local
+  documentRoot: /var/www/htdocs
 ```
 
 See the [godoc](https://pkg.go.dev/github.com/c2FmZQ/tlsproxy/proxy#section-documentation) and the [examples](https://github.com/c2FmZQ/tlsproxy/blob/main/examples) directory for more details.

--- a/proxy/backend-http.go
+++ b/proxy/backend-http.go
@@ -34,6 +34,9 @@ import (
 	"net"
 	"net/http"
 	"net/http/httputil"
+	"os"
+	"path"
+	"path/filepath"
 	"regexp"
 	"runtime/debug"
 	"slices"
@@ -85,17 +88,84 @@ func (be *Backend) localHandler() http.Handler {
 		if !be.handleLocalEndpointsAndAuthorize(w, req) {
 			return
 		}
-		log.Printf("PRX %s ➔ %s %s ➔ status:%d (%q)", formatReqDesc(req), req.Method, req.URL, http.StatusNotFound, userAgent(req))
-		http.NotFound(w, req)
+		be.serveStaticFiles(w, req, be.DocumentRoot, "")
 	})
+}
+
+func pathClean(p string) string {
+	pp := path.Clean(p)
+	if pp == "." {
+		pp = "/"
+	}
+	if pp != "/" && strings.HasSuffix(p, "/") {
+		pp += "/"
+	}
+	return pp
+}
+
+func (be *Backend) serveStaticFiles(w http.ResponseWriter, req *http.Request, docRoot, prefix string) {
+	notFound := func() {
+		log.Printf("REQ %s ➔ %s %s ➔ status:%d (%q)", formatReqDesc(req), req.Method, req.URL, http.StatusNotFound, userAgent(req))
+		http.NotFound(w, req)
+	}
+	redirect := func(u string) {
+		log.Printf("REQ %s ➔ %s %s ➔ status:%d (%q)", formatReqDesc(req), req.Method, req.URL.Path, http.StatusMovedPermanently, userAgent(req))
+		http.Redirect(w, req, u, http.StatusMovedPermanently)
+	}
+
+	if docRoot == "" {
+		notFound()
+		return
+	}
+
+	cleanPath := pathClean(req.URL.Path)
+	if cleanPath != req.URL.Path {
+		redirect(cleanPath)
+		return
+	}
+	p := strings.TrimPrefix(cleanPath, prefix)
+	p = strings.TrimPrefix(p, "/")
+	for _, pp := range strings.Split(p, "/") {
+		if strings.HasPrefix(pp, ".") || strings.Contains(pp, `\`) {
+			notFound()
+			return
+		}
+	}
+	p = filepath.Join(docRoot, filepath.FromSlash(p))
+	fi, err := os.Stat(p)
+	if err != nil {
+		notFound()
+		return
+	}
+	if fi.IsDir() {
+		if !strings.HasSuffix(cleanPath, "/") {
+			redirect(cleanPath + "/")
+			return
+		}
+		p = filepath.Join(p, "index.html")
+		if s, err := os.Stat(p); err != nil || s.IsDir() {
+			log.Printf("REQ %s ➔ %s %s ➔ status:%d (%q)", formatReqDesc(req), req.Method, req.URL.Path, http.StatusForbidden, userAgent(req))
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+	} else if strings.HasSuffix(cleanPath, "/") {
+		redirect(strings.TrimSuffix(cleanPath, "/"))
+		return
+	}
+	f, err := os.Open(p)
+	if err != nil {
+		notFound()
+		return
+	}
+	defer f.Close()
+	log.Printf("REQ %s ➔ %s %s ➔ status:%d (%q)", formatReqDesc(req), req.Method, req.URL.Path, http.StatusOK, userAgent(req))
+	be.setAltSvc(w.Header(), req)
+	http.ServeContent(w, req, p, fi.ModTime(), f)
 }
 
 // reverseProxy returns an HTTP handler for backends that act as a reverse
 // proxy for remote servers. This handler can also serve local endpoints.
 func (be *Backend) reverseProxy() http.Handler {
-	if len(be.Addresses) == 0 {
-		return be.localHandler()
-	}
 	reverseProxy := &httputil.ReverseProxy{
 		Director:       be.reverseProxyDirector,
 		Transport:      be.reverseProxyTransport(),
@@ -142,6 +212,59 @@ func (be *Backend) reverseProxy() http.Handler {
 		}
 		ctx = context.WithValue(ctx, ctxURLKey, req.URL.String())
 
+		// Apply the forward rate limit. The first request was already
+		// counted when the connection was established.
+		if conn, ok := ctx.Value(connCtxKey).(annotatedConnection); ok {
+			if !conn.Annotation(requestFlagKey, false).(bool) {
+				conn.SetAnnotation(requestFlagKey, true)
+			} else if err := be.connLimit.Wait(ctx); err != nil {
+				http.Error(w, "ctx", http.StatusInternalServerError)
+				return
+			}
+		}
+
+		// Apply path overrides that may direct the request to a
+		// different address. The actual override will be applied in
+		// dial(), but we need to set req.URL.Host to a unique value
+		// so that the http client will not re-use connections with
+		// other addresses.
+		override := ""
+		proxyProtoVersion := be.proxyProtocolVersion
+		cleanPath := pathClean(req.URL.Path)
+	L:
+		for i, po := range be.PathOverrides {
+			for _, prefix := range po.Paths {
+				if cleanPath+"/" == prefix {
+					log.Printf("REQ %s ➔ %s %s ➔ status:%d (%q)", formatReqDesc(req), req.Method, req.URL.Path, http.StatusMovedPermanently, userAgent(req))
+					http.Redirect(w, req, cleanPath+"/", http.StatusMovedPermanently)
+					return
+				}
+				if !strings.HasPrefix(cleanPath, prefix) {
+					continue
+				}
+				if len(po.Addresses) == 0 {
+					be.serveStaticFiles(w, req, po.DocumentRoot, prefix)
+					return
+				}
+				ctx = context.WithValue(ctx, ctxOverrideIDKey, i)
+				override = fmt.Sprintf("%d", i)
+				proxyProtoVersion = po.proxyProtocolVersion
+				break L
+			}
+		}
+		if len(be.Addresses) == 0 {
+			be.serveStaticFiles(w, req, be.DocumentRoot, "")
+			return
+		}
+
+		hostKey := bytes.NewBufferString(serverName + ";" + override)
+		if proxyProtoVersion > 0 {
+			hostKey.WriteByte(';')
+			writeProxyHeader(proxyProtoVersion, hostKey, req.Context().Value(connCtxKey).(anyConn))
+		}
+		h := sha256.Sum256(hostKey.Bytes())
+		req.URL.Host = hex.EncodeToString(h[:])
+
 		// Detect forwarding loops using the via headers.
 		me := localNetConn(req.Context().Value(connCtxKey).(anyConn)).LocalAddr().String()
 		var hops []string
@@ -160,44 +283,6 @@ func (be *Backend) reverseProxy() http.Handler {
 		hops = append(hops, req.Proto+" "+me)
 		req.Header.Set(viaHeader, strings.Join(hops, ", "))
 
-		// Apply path overrides that may direct the request to a
-		// different address. The actual override will be applied in
-		// dial(), but we need to set req.URL.Host to a unique value
-		// so that the http client will not re-use connections with
-		// other addresses.
-		override := ""
-		proxyProtoVersion := be.proxyProtocolVersion
-	L:
-		for i, po := range be.PathOverrides {
-			for _, prefix := range po.Paths {
-				if !strings.HasPrefix(req.URL.Path, prefix) {
-					continue
-				}
-				ctx = context.WithValue(ctx, ctxOverrideIDKey, i)
-				override = fmt.Sprintf("%d", i)
-				proxyProtoVersion = po.proxyProtocolVersion
-				break L
-			}
-		}
-
-		hostKey := bytes.NewBufferString(serverName + ";" + override)
-		if proxyProtoVersion > 0 {
-			hostKey.WriteByte(';')
-			writeProxyHeader(proxyProtoVersion, hostKey, req.Context().Value(connCtxKey).(anyConn))
-		}
-		h := sha256.Sum256(hostKey.Bytes())
-		req.URL.Host = hex.EncodeToString(h[:])
-
-		// Apply the forward rate limit. The first request was already
-		// counted when the connection was established.
-		if conn, ok := ctx.Value(connCtxKey).(annotatedConnection); ok {
-			if !conn.Annotation(requestFlagKey, false).(bool) {
-				conn.SetAnnotation(requestFlagKey, true)
-			} else if err := be.connLimit.Wait(ctx); err != nil {
-				http.Error(w, "ctx", http.StatusInternalServerError)
-				return
-			}
-		}
 		reverseProxy.ServeHTTP(w, req.WithContext(ctx))
 	})
 }

--- a/proxy/backend-http.go
+++ b/proxy/backend-http.go
@@ -93,6 +93,9 @@ func (be *Backend) localHandler() http.Handler {
 }
 
 func pathClean(p string) string {
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
 	pp := path.Clean(p)
 	if pp == "." {
 		pp = "/"

--- a/proxy/backend-http.go
+++ b/proxy/backend-http.go
@@ -160,6 +160,11 @@ func (be *Backend) serveStaticFiles(w http.ResponseWriter, req *http.Request, do
 		notFound()
 		return
 	}
+	if fi, err := f.Stat(); err != nil || !fi.Mode().IsRegular() {
+		log.Printf("REQ %s ➔ %s %s ➔ status:%d (%q)", formatReqDesc(req), req.Method, req.URL.Path, http.StatusForbidden, userAgent(req))
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
 	defer f.Close()
 	log.Printf("REQ %s ➔ %s %s ➔ status:%d (%q)", formatReqDesc(req), req.Method, req.URL.Path, http.StatusOK, userAgent(req))
 	be.setAltSvc(w.Header(), req)

--- a/proxy/backend-sso.go
+++ b/proxy/backend-sso.go
@@ -334,8 +334,9 @@ func pathMatches(prefixes []string, path string) bool {
 	if len(prefixes) == 0 {
 		return true
 	}
+	cleanPath := pathClean(path)
 	for _, p := range prefixes {
-		if strings.HasPrefix(path, p) {
+		if strings.HasPrefix(path, p) || strings.HasPrefix(cleanPath, p) {
 			return true
 		}
 	}

--- a/proxy/metrics-template.html
+++ b/proxy/metrics-template.html
@@ -244,6 +244,9 @@ function selectTab(target) {
 {{- range $i, $be := .Backends }}
   <div style="margin-top: 1rem;">
 Backend[{{$i}}]: {{.Mode}} {{.ALPNProtos}} {{.BackendProto}} {{.SSO}}
+  {{- if len .DocumentRoot | ne 0 }}
+    <div style="margin-left: 1rem;">DocumentRoot: {{ .DocumentRoot }}</div>
+  {{- end }}
   {{- if len .ServerNames | ne 0 }}
     <div style="margin-left: 1rem;">ServerNames:</div>
     {{- range .ServerNames }}

--- a/proxy/metrics.go
+++ b/proxy/metrics.go
@@ -167,6 +167,7 @@ func (p *Proxy) metricsHandler(w http.ResponseWriter, req *http.Request) {
 		BackendProto string
 		ClientAuth   string
 		SSO          string
+		DocumentRoot string
 		ServerNames  []string
 		Addresses    []string
 		Handlers     []handler
@@ -411,6 +412,7 @@ func (p *Proxy) metricsHandler(w http.ResponseWriter, req *http.Request) {
 			}
 			backend.ALPNProtos = protos
 		}
+		backend.DocumentRoot = be.DocumentRoot
 		for _, sn := range be.ServerNames {
 			backend.ServerNames = append(backend.ServerNames, idnaToUnicode(sn))
 		}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -205,7 +205,7 @@ func TestProxyBackends(t *testing.T) {
 				PathOverrides: []*PathOverride{
 					{
 						Paths: []string{
-							"/foo",
+							"/foo/",
 						},
 						Addresses: []string{
 							be9.String(),
@@ -349,7 +349,7 @@ func TestProxyBackends(t *testing.T) {
 		{desc: "Unknown server name", host: "foo.example.com", expError: true},
 		{desc: "Hit backend7", host: "passthrough.example.com", want: "Hello from backend7\n"},
 		{desc: "Hit backend8", host: "http.example.com", want: "[backend8] /", http: "/"},
-		{desc: "Hit backend8 /foo", host: "http.example.com", want: "[backend9] /foo", http: "/foo"},
+		{desc: "Hit backend8 /foo", host: "http.example.com", want: "[backend9] /foo/", http: "/foo"},
 		{desc: "Hit backend9", host: "https.example.com", want: "[backend9] /", http: "/", certName: "client.example.com"},
 		{desc: "Hit backend10", host: "tls-pki.example.com", want: "Hello from backend10\n", certName: "client.example.com"},
 		{desc: "Hit backend11", host: "http-proxy.example.com", want: "[backend11] LOCALADDR /", http: "/"},

--- a/proxy/static_test.go
+++ b/proxy/static_test.go
@@ -1,0 +1,210 @@
+// MIT License
+//
+// Copyright (c) 2024 TTBT Enterprises LLC
+// Copyright (c) 2024 Robin Thellend <rthellend@rthellend.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package proxy
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/c2FmZQ/tlsproxy/certmanager"
+)
+
+func TestStaticFiles(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ca, err := certmanager.New("root-ca.example.com", t.Logf)
+	if err != nil {
+		t.Fatalf("certmanager.New: %v", err)
+	}
+
+	docRoot := t.TempDir()
+	type testType struct {
+		host    string
+		name    string
+		content string
+	}
+	testFiles := []testType{
+		{"www.example.com", "index.html", "hello"},
+		{"www.example.com", "foo.html", "foo"},
+		{"www.example.com", "foo/index.html", "hi"},
+		{"www.example.com", "foo/bar.html", "bar"},
+		{"www.example.com", "foo/bar/bar", "barbar"},
+		{"xyz.example.com", "index.html", "XYZ"},
+	}
+	for _, f := range testFiles {
+		fname := filepath.Join(docRoot, f.host, f.name)
+		os.MkdirAll(filepath.Dir(fname), 0o755)
+		if err := os.WriteFile(fname, []byte(f.content), 0o644); err != nil {
+			t.Fatalf("os.WriteFile(%s): %v", f.name, err)
+		}
+	}
+	os.MkdirAll(filepath.Join(docRoot, ".git"), 0o755)
+	if err := os.WriteFile(filepath.Join(docRoot, ".git", "config"), []byte("..."), 0o644); err != nil {
+		t.Fatalf("os.WriteFile(.git/config): %v", err)
+	}
+
+	proxy := newTestProxy(
+		&Config{
+			HTTPAddr: "localhost:0",
+			TLSAddr:  "localhost:0",
+			CacheDir: t.TempDir(),
+			MaxOpen:  100,
+			Backends: []*Backend{
+				{
+					ServerNames: []string{
+						"www.example.com",
+					},
+					Mode:         "LOCAL",
+					DocumentRoot: filepath.Join(docRoot, "www.example.com"),
+				},
+				{
+					ServerNames: []string{
+						"xyz.example.com",
+					},
+					Mode:         "HTTP",
+					DocumentRoot: filepath.Join(docRoot, "xyz.example.com"),
+					PathOverrides: []*PathOverride{
+						{
+							Paths: []string{
+								"/abc/",
+							},
+							DocumentRoot: filepath.Join(docRoot, "www.example.com"),
+						},
+					},
+				},
+				{
+					ServerNames: []string{
+						"aaa.example.com",
+					},
+					Mode: "HTTP",
+				},
+			},
+		},
+		ca,
+	)
+	if err := proxy.Start(ctx); err != nil {
+		t.Fatalf("proxy.Start: %v", err)
+	}
+	defer proxy.Stop()
+
+	get := func(urlToGet string) (int, string) {
+		u, err := url.Parse(urlToGet)
+		if err != nil {
+			t.Fatalf("%q: %v", urlToGet, err)
+		}
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = &tls.Config{
+			RootCAs: ca.RootCACertPool(),
+		}
+		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, "tcp", proxy.listener.Addr().String())
+		}
+		client := http.Client{
+			Transport: transport,
+		}
+		req := &http.Request{
+			Method: "GET",
+			URL:    u,
+			Host:   u.Host,
+			Header: make(http.Header),
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("%s: get failed: %v", urlToGet, err)
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("%s: body read: %v", urlToGet, err)
+		}
+		if err := resp.Body.Close(); err != nil {
+			t.Fatalf("%s: body close: %v", urlToGet, err)
+		}
+		return resp.StatusCode, string(body)
+	}
+
+	testFiles = append(testFiles,
+		testType{"www.example.com", "", "hello"},
+		testType{"www.example.com", "index.html/", "hello"},
+		testType{"www.example.com", "index.html/.", "hello"},
+		testType{"www.example.com", "/", "hello"},
+		testType{"www.example.com", "////", "hello"},
+		testType{"www.example.com", "foo", "hi"},
+		testType{"www.example.com", "foo/", "hi"},
+		testType{"www.example.com", "foo/.", "hi"},
+		testType{"www.example.com", "./foo/.", "hi"},
+		testType{"www.example.com", "foo/..", "hello"},
+		testType{"www.example.com", "../xxx/../..", "hello"},
+		testType{"www.example.com", "../xxx/../../", "hello"},
+		testType{"xyz.example.com", "abc", "hello"},
+		testType{"xyz.example.com", "/abc/", "hello"},
+		testType{"xyz.example.com", "abc/", "hello"},
+		testType{"xyz.example.com", "abc/foo", "hi"},
+		testType{"xyz.example.com", "abc/foo/", "hi"},
+		testType{"xyz.example.com", "abc/foo/index.html", "hi"},
+		testType{"xyz.example.com", "abc//foo", "hi"},
+	)
+
+	for _, f := range testFiles {
+		code, body := get("https://" + f.host + "/" + f.name)
+		if got, want := code, 200; got != want {
+			t.Errorf("Code = %v, want %v", got, want)
+			continue
+		}
+		if got, want := body, f.content; got != want {
+			t.Errorf("Body = %v, want %v", got, want)
+		}
+	}
+
+	for _, f := range []struct {
+		host string
+		name string
+		code int
+	}{
+		{"www.example.com", "blah", 404},
+		{"www.example.com", "foo/bar", 403},
+		{"www.example.com", "../../../../../../../../etc/passwd", 404},
+		{"www.example.com", ".git/config", 404},
+		{"www.example.com", "foo/.git/config", 404},
+		{"www.example.com", `abc\foo`, 404},
+		{"xyz.example.com", "abc/.git/config", 404},
+		{"aaa.example.com", "", 404},
+		{"aaa.example.com", "/", 404},
+		{"aaa.example.com", "../../../../../../../../etc/passwd", 404},
+		{"aaa.example.com", "proxy.go", 404},
+	} {
+		code, _ := get("https://" + f.host + "/" + f.name)
+		if got, want := code, f.code; got != want {
+			t.Errorf("Code = %v, want %v", got, want)
+		}
+	}
+}

--- a/proxy/static_test.go
+++ b/proxy/static_test.go
@@ -208,3 +208,38 @@ func TestStaticFiles(t *testing.T) {
 		}
 	}
 }
+
+func TestPathClean(t *testing.T) {
+	for _, tc := range []struct {
+		in, out string
+	}{
+		{"", "/"},
+		{"/", "/"},
+		{"//", "/"},
+		{"///", "/"},
+		{"foo", "/foo"},
+		{"foo/", "/foo/"},
+		{"/foo", "/foo"},
+		{"//foo", "/foo"},
+		{"///foo", "/foo"},
+		{".", "/"},
+		{"./", "/"},
+		{".//", "/"},
+		{"..", "/"},
+		{"/.", "/"},
+		{"/..", "/"},
+		{"/foo/.", "/foo"},
+		{"/foo/..", "/"},
+		{"/foo/../../../../bar", "/bar"},
+		{"/foo/./bar", "/foo/bar"},
+		{"/foo/./bar/", "/foo/bar/"},
+		{"/foo/./../bar", "/bar"},
+		{"/../../bar", "/bar"},
+		{"///..//../bar", "/bar"},
+		{"/././bar", "/bar"},
+	} {
+		if got, want := pathClean(tc.in), tc.out; got != want {
+			t.Errorf("pathClean(%q) = %q, want %q", tc.in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
### Description

When `documentRoot` is set, tlsproxy will serve static content from that directory. This option is only available when mode is `local`, `http`, or `https`, and the backend's addresses field is empty.

### Type of change

* [x] New feature
* [ ] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)

### How is this change tested ?

* [x] Unit tests
* [ ] Manual tests (explain)
* [ ] Tests are not needed
