### PR TITLE
Redirect POST with 303

### DIFF
--- a/proxy/backend-http.go
+++ b/proxy/backend-http.go
@@ -244,7 +244,7 @@ func (be *Backend) reverseProxy() http.Handler {
 			for _, prefix := range po.Paths {
 				if cleanPath+"/" == prefix {
 					code := http.StatusMovedPermanently
-					if req.Method == http.MethodPost {
+					if req.Method != http.MethodGet && req.Method != http.MethodHead {
 						code = http.StatusSeeOther
 					}
 					log.Printf("REQ %s ➔ %s %s ➔ status:%d (%q)", formatReqDesc(req), req.Method, req.URL.Path, code, userAgent(req))

--- a/proxy/backend-http.go
+++ b/proxy/backend-http.go
@@ -243,8 +243,12 @@ func (be *Backend) reverseProxy() http.Handler {
 		for i, po := range be.PathOverrides {
 			for _, prefix := range po.Paths {
 				if cleanPath+"/" == prefix {
-					log.Printf("REQ %s ➔ %s %s ➔ status:%d (%q)", formatReqDesc(req), req.Method, req.URL.Path, http.StatusMovedPermanently, userAgent(req))
-					http.Redirect(w, req, cleanPath+"/", http.StatusMovedPermanently)
+					code := http.StatusMovedPermanently
+					if req.Method == http.MethodPost {
+						code = http.StatusSeeOther
+					}
+					log.Printf("REQ %s ➔ %s %s ➔ status:%d (%q)", formatReqDesc(req), req.Method, req.URL.Path, code, userAgent(req))
+					http.Redirect(w, req, cleanPath+"/", code)
 					return
 				}
 				if !strings.HasPrefix(cleanPath, prefix) {


### PR DESCRIPTION
### Description

When redirecting POST (and other non GET/HEAD) requests, use status code 303 (See Other).

### Type of change

* [ ] New feature
* [ ] Feature improvement
* [x] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)

### How is this change tested ?

* [x] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
