### PR TITLE
Add forwardHttpHeaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+### :star: Feature improvements
+
+* Add `forwardHttpHeaders` to set HTTP headers in the forwarded HTTP requests. Headers that already exist are overwritten.
+
 ### :wrench: Misc
 
 * Update go dependencies:

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -306,6 +306,10 @@ type Backend struct {
 	// long to wait before trying the next address in the list. The default
 	// value is 30 seconds.
 	ForwardTimeout time.Duration `yaml:"forwardTimeout"`
+	// ForwardHTTPHeaders is a list of HTTP headers to add to the forwarded
+	// request. Headers that already exist are overwritten.
+	ForwardHTTPHeaders map[string]string `yaml:"forwardHttpHeaders,omitempty"`
+
 	// PathOverrides specifies different backend parameters for some path
 	// prefixes.
 	// Paths are matched by prefix in the order that they are listed here.
@@ -608,6 +612,9 @@ type PathOverride struct {
 	// By default, the proxy protocol is not enabled.
 	// See https://www.haproxy.org/download/2.3/doc/proxy-protocol.txt
 	ProxyProtocolVersion string `yaml:"proxyProtocolVersion,omitempty"`
+	// ForwardHTTPHeaders is a list of HTTP headers to add to the forwarded
+	// request. Headers that already exist are overwritten.
+	ForwardHTTPHeaders *map[string]string `yaml:"forwardHttpHeaders,omitempty"`
 	// SanitizePath indicates that the request's path should be sanitized
 	// before forwarding the request to the backend.
 	SanitizePath *bool `yaml:"sanitizePath,omitempty"`


### PR DESCRIPTION
### Description

The backend parameter `forwardHttpHeaders` is used to set HTTP headers in the forwarded request. Headers that already exist are overwritten.

### Type of change

* [ ] New feature
* [x] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)


### How is this change tested ?

* [x] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
