### PR TITLE
Add keyword expansion to backend http headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # TLSPROXY Release Notes
 
+## Next
+
+### :star: Feature improvements
+
+* When `forwardHttpHeaders` is used, special keywords are automatically expanded from the header values:
+  * `${NETWORK}` is either tcp or udp.
+  * `${LOCAL_ADDR}` is the local address of the network connection.
+  * `${REMOTE_ADDR}` is the remote address of the network connection.
+  * `${LOCAL_IP}` is the local IP address of the network connection.
+  * `${REMOTE_IP}` is the remote IP address of the network connection.
+  * `${SERVER_NAME}` is the server name requested by the client.
+  * `${JWT:xxxx}` expands to the value of claim `xxxx` from the ID token.
+
 ## v0.9.1
 
 ### :wrench: Misc

--- a/proxy/backend-http.go
+++ b/proxy/backend-http.go
@@ -321,7 +321,7 @@ func (be *Backend) reverseProxy() http.Handler {
 			req.URL.Path = cleanPath
 		}
 		for k, v := range httpHeaders {
-			v = be.expandVars(v, req)
+			v = expandVars(v, req)
 			if v != "" {
 				req.Header.Set(k, v)
 				if strings.ToLower(k) == strings.ToLower(hostHeader) {
@@ -346,7 +346,7 @@ func addr2ip(addr net.Addr) string {
 	}
 }
 
-func (be *Backend) expandVars(s string, req *http.Request) string {
+func expandVars(s string, req *http.Request) string {
 	ctx := req.Context()
 	claims := claimsFromCtx(ctx)
 	conn := ctx.Value(connCtxKey).(anyConn)

--- a/proxy/backend-http_test.go
+++ b/proxy/backend-http_test.go
@@ -1,0 +1,122 @@
+// MIT License
+//
+// Copyright (c) 2024 TTBT Enterprises LLC
+// Copyright (c) 2024 Robin Thellend <rthellend@rthellend.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package proxy
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+
+	jwt "github.com/golang-jwt/jwt/v5"
+)
+
+func TestExpandVars(t *testing.T) {
+	ctx := context.WithValue(context.Background(), authCtxKey, jwt.MapClaims{
+		"email": "bob@example.com",
+		"name":  "Bob",
+	})
+	ctx = context.WithValue(ctx, connCtxKey, mockConn{
+		localAddr: &net.TCPAddr{
+			IP:   net.IPv4(1, 2, 3, 4),
+			Port: 443,
+		},
+		remoteAddr: &net.TCPAddr{
+			IP:   net.IPv4(11, 22, 33, 44),
+			Port: 5678,
+		},
+		annotations: map[string]any{
+			serverNameKey: "www.example.com",
+		},
+	})
+	req, err := http.NewRequestWithContext(ctx, "GET", "https://www.example.com/", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequestWithContext: %v", err)
+	}
+
+	for _, tc := range []struct {
+		in, out string
+	}{
+		{in: "FOO", out: "FOO"},
+		{in: "$LOCAL_ADDR", out: "1.2.3.4:443"},
+		{in: "$LOCAL_IP", out: "1.2.3.4"},
+		{in: "$REMOTE_ADDR", out: "11.22.33.44:5678"},
+		{in: "$REMOTE_IP", out: "11.22.33.44"},
+		{in: "$SERVER_NAME", out: "www.example.com"},
+		{in: "${JWT:email}", out: "bob@example.com"},
+		{in: "${JWT:name}", out: "Bob"},
+		{in: "${JWT:foo}", out: ""},
+		{in: "FOO ${SERVER_NAME} ${NETWORK} ${LOCAL_IP} BAR", out: "FOO www.example.com tcp 1.2.3.4 BAR"},
+	} {
+		if got, want := expandVars(tc.in, req), tc.out; got != want {
+			t.Errorf("expandVars(%q) = %q, want %q", tc.in, got, want)
+		}
+	}
+
+}
+
+type mockConn struct {
+	localAddr   net.Addr
+	remoteAddr  net.Addr
+	annotations map[string]any
+}
+
+func (c mockConn) LocalAddr() net.Addr {
+	return c.localAddr
+}
+
+func (c mockConn) RemoteAddr() net.Addr {
+	return c.remoteAddr
+}
+
+func (mockConn) Close() error {
+	return nil
+}
+
+func (c mockConn) Annotation(key string, defaultValue any) any {
+	if v, ok := c.annotations[key]; ok {
+		return v
+	}
+	return defaultValue
+}
+
+func (c mockConn) SetAnnotation(key string, value any) {
+	c.annotations[key] = value
+}
+
+func (mockConn) BytesSent() int64 {
+	return 0
+}
+
+func (mockConn) BytesReceived() int64 {
+	return 0
+}
+
+func (mockConn) ByteRateSent() float64 {
+	return 0
+}
+
+func (mockConn) ByteRateReceived() float64 {
+	return 0
+}

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -556,6 +556,11 @@ type BackendSSO struct {
 	Paths []string `yaml:"paths,omitempty"`
 	// SetUserIDHeader indicates that the x-tlsproxy-user-id header should
 	// be set with the email address of the user.
+	//
+	// This is equivalent to:
+	//   ForwardHTTPHeaders: map[string]string{
+	//       "x-tlsproxy-user-id": "${JWT:email}",
+	//   }
 	SetUserIDHeader bool `yaml:"setUserIdHeader,omitempty"`
 	// GenerateIDTokens indicates that the proxy should generate ID tokens
 	// for authenticated users.
@@ -614,6 +619,15 @@ type PathOverride struct {
 	ProxyProtocolVersion string `yaml:"proxyProtocolVersion,omitempty"`
 	// ForwardHTTPHeaders is a list of HTTP headers to add to the forwarded
 	// request. Headers that already exist are overwritten.
+	//
+	// Special keywords are automatically expanded from the header values:
+	//   ${NETWORK} is either tcp or udp.
+	//   ${LOCAL_ADDR} is the local address of the network connection.
+	//   ${REMOTE_ADDR} is the remote address of the network connection.
+	//   ${LOCAL_IP} is the local IP address of the network connection.
+	//   ${REMOTE_IP} is the remote IP address of the network connection.
+	//   ${SERVER_NAME} is the server name requested by the client.
+	//   ${JWT:xxxx} expands to the value of claim xxxx from the ID token.
 	ForwardHTTPHeaders *map[string]string `yaml:"forwardHttpHeaders,omitempty"`
 	// SanitizePath indicates that the request's path should be sanitized
 	// before forwarding the request to the backend.

--- a/proxy/util.go
+++ b/proxy/util.go
@@ -67,9 +67,7 @@ func annotatedConn(c anyConn) annotatedConnection {
 	switch c := c.(type) {
 	case *tls.Conn:
 		return netwConn(c.NetConn())
-	case *netw.Conn:
-		return c
-	case *netw.QUICConn:
+	case annotatedConnection:
 		return c
 	default:
 		panic(c)


### PR DESCRIPTION
### Description

Special keywords are automatically expanded from the header values:
 * `${NETWORK}` is either tcp or udp.
 * `${LOCAL_ADDR}` is the local address of the network connection.
 * `${REMOTE_ADDR}` is the remote address of the network connection.
 * `${LOCAL_IP}` is the local IP address of the network connection.
 * `${REMOTE_IP}` is the remote IP address of the network connection.
 * `${SERVER_NAME}` is the server name requested by the client.
 * `${JWT:xxxx}` expands to the value of claim `xxxx` from the ID token, e.g. `${JWT:email}`.

### Type of change

* [ ] New feature
* [x] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)

### How is this change tested ?

* [x] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
