### PR TITLE
Don't send `content-length: -1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # TLSPROXY Release Notes
 
+## unreleased
+
+### :wrench: Bug fix
+
+* Don't send `content-length: -1` to backends. This caused `400` errors in some configurations.
+
 ## v0.10.6
 
 ### :wrench: Misc

--- a/proxy/backend-http.go
+++ b/proxy/backend-http.go
@@ -331,6 +331,10 @@ func (be *Backend) reverseProxy() http.Handler {
 				req.Header.Del(k)
 			}
 		}
+		if req.ContentLength < 0 {
+			req.ContentLength = 0
+			req.Header.Del("Content-Length")
+		}
 		reverseProxy.ServeHTTP(w, req.WithContext(ctx))
 	})
 }


### PR DESCRIPTION
### Description

Don't send `content-length: -1` to backends. This caused `400` errors from backends in some configurations. This bug was a side-effect of a change in quic-go v0.47.0 (https://github.com/quic-go/quic-go/pull/4645).

### Type of change

* [ ] New feature
* [ ] Feature improvement
* [x] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)


### How is this change tested ?

* [ ] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
