### PR TITLE
Fix HTTP POST for HTTP and HTTPS backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## unreleased
 
+### :wrench: Bug fix
+
+* Another fix for `content-length: -1`. The change in v0.10.7 broke HTTP POST requests.
+
 ### :wrench: Misc
 
 * Update go dependencies:

--- a/proxy/backend-http.go
+++ b/proxy/backend-http.go
@@ -331,7 +331,7 @@ func (be *Backend) reverseProxy() http.Handler {
 				req.Header.Del(k)
 			}
 		}
-		if req.ContentLength < 0 {
+		if req.ContentLength < 0 && req.Method != http.MethodPost && req.Method != http.MethodPut && req.Method != http.MethodPatch {
 			req.ContentLength = 0
 			req.Header.Del("Content-Length")
 		}


### PR DESCRIPTION
### Description

The "bug fix" in v0.10.7 broke HTTP POST requests for HTTP and HTTPS backends. The post body was effectively removed.

https://github.com/c2FmZQ/tlsproxy/issues/148

### Type of change

* [ ] New feature
* [ ] Feature improvement
* [x] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)

### How is this change tested ?

* [ ] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
