### PR TITLE
Add support for TLS certificates stored locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## unreleased
 
-### :star2: New feature
+### :star2: New features
 
 * Add a configuration option to filter out logged data. See `LogFilter` in [config.go](https://github.com/c2FmZQ/tlsproxy/blob/main/proxy/config.go). This can be set at the top level config, the backend level config, or both.
+* Add support for TLS certificates stored locally. See `tlsCertificates` in [config.go](https://github.com/c2FmZQ/tlsproxy/blob/main/proxy/config.go).
 
 ### :wrench: Misc
 * Update go: 1.23.3

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Overview of features:
 * [x] Simple round-robin load balancing between servers.
 * [x] Support any ALPN protocol in TLS, TLSPASSTHROUGH, QUIC, or TCP mode.
 * [x] OCSP stapling and OCSP certificate verification.
+* [x] Support for TLS certificates stored locally.
 * [x] Hardware-backed cryptographic keys for encryption and signing with a [TPM](https://github.com/c2FmZQ/tlsproxy/blob/main/docs/TPM.md).
 * [x] Use the same address (IPAddr:port) for any number of server names, e.g. foo.example.com and bar.example.com on the same xxx.xxx.xxx.xxx:443.
 

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -158,6 +158,10 @@ type Config struct {
 	// PKI is a list of locally hosted and managed Certificate Authorities
 	// that can be used to authenticate TLS clients and backend servers.
 	PKI []*ConfigPKI `yaml:"pki,omitempty"`
+	// TLSCertificates is a lists of TLS certificates that should be used
+	// instead of Let's Encrypt. If a certificate is needed but there is no
+	// match in this list, Let's Encrypt is used.
+	TLSCertificates []*TLSCertificate `yaml:"tlsCertificates"`
 	// BWLimits is the list of named bandwidth limit groups.
 	// Each backend can be associated with one group. The group's limits
 	// are shared between all the backends associated with it.
@@ -184,6 +188,19 @@ type LogFilter struct {
 	Requests *bool `yaml:"requests"`
 	// Errors indicates that errors are logged.
 	Errors *bool `yaml:"errors"`
+}
+
+// TLSCertificate specifies TLS keys and certificates to use for given server
+// names.
+type TLSCertificate struct {
+	// ServerNames is a list of server names for which this certificate
+	// should be used.
+	ServerNames []string `yaml:"serverNames"`
+	// KeyFile is the name of the file that contains the private key.
+	KeyFile string `yaml:"key"`
+	// CertFile is the name of the file that contains the X.509 certificate
+	// chain.
+	CertFile string `yaml:"cert"`
 }
 
 // Backend encapsulates the data of one backend.

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -201,7 +201,7 @@ func New(cfg *Config, passphrase []byte) (*Proxy, error) {
 		Cache: autocertcache.New("autocert", store),
 		Email: cfg.Email,
 	}
-	if p.cfg.AcceptTOS {
+	if cfg.AcceptTOS {
 		p.certManager.(*autocert.Manager).Prompt = autocert.AcceptTOS
 	}
 	p.tpm = pTPM

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -198,6 +198,10 @@ func New(cfg *Config, passphrase []byte) (*Proxy, error) {
 	}
 
 	p.certManager = &autocert.Manager{
+		Prompt: func(string) bool {
+			p.logError("AcceptTOS must be set in the config")
+			return false
+		},
 		Cache: autocertcache.New("autocert", store),
 		Email: cfg.Email,
 	}


### PR DESCRIPTION
### Description

Add support for TLS certificates stored locally

```yaml
tlsCertificates:
  - serverNames: [foo.example.com]
    keyFile: /path/to/keyfile.pem
    certFile: /path/to/certfile.pem
```

https://github.com/c2FmZQ/tlsproxy/issues/132

### Type of change

* [x] New feature
* [ ] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)


### How is this change tested ?

* [x] Unit tests
* [ ] Manual tests (explain)
* [ ] Tests are not needed
