### PR TITLE
Expand passkeys to work without resident keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## next
 
+### :star: Feature improvements
+
+* Improve passkey authentication to support WebAuthn devices without discoverable credentials.
+
 ### :wrench: Misc
 
 * Update go dependencies:

--- a/proxy/backend-sso.go
+++ b/proxy/backend-sso.go
@@ -171,8 +171,9 @@ func (be *Backend) serveSSOStatus(w http.ResponseWriter, req *http.Request) {
 		Key, Value string
 	}
 	var data struct {
-		Token  string
-		Claims []kv
+		Token    string
+		Claims   []kv
+		Passkeys bool
 	}
 	for _, k := range keys {
 		if k == "iat" {
@@ -195,6 +196,7 @@ func (be *Backend) serveSSOStatus(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	data.Token = token
+	_, data.Passkeys = be.SSO.p.(*passkeys.Manager)
 	ssoStatusTemplate.Execute(w, data)
 }
 

--- a/proxy/internal/idp/idp.go
+++ b/proxy/internal/idp/idp.go
@@ -24,21 +24,29 @@
 package idp
 
 type LoginOptions struct {
-	LoginHint     string
-	SelectAccount bool
+	loginHint     string
+	selectAccount bool
+}
+
+func (o LoginOptions) LoginHint() string {
+	return o.loginHint
+}
+
+func (o LoginOptions) SelectAccount() bool {
+	return o.selectAccount
 }
 
 type Option func(*LoginOptions)
 
 func WithLoginHint(v string) Option {
 	return func(o *LoginOptions) {
-		o.LoginHint = v
+		o.loginHint = v
 	}
 }
 
 func WithSelectAccount(v bool) Option {
 	return func(o *LoginOptions) {
-		o.SelectAccount = v
+		o.selectAccount = v
 	}
 }
 

--- a/proxy/internal/idp/idp.go
+++ b/proxy/internal/idp/idp.go
@@ -1,0 +1,51 @@
+// MIT License
+//
+// Copyright (c) 2024 TTBT Enterprises LLC
+// Copyright (c) 2024 Robin Thellend <rthellend@rthellend.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package idp
+
+type LoginOptions struct {
+	LoginHint     string
+	SelectAccount bool
+}
+
+type Option func(*LoginOptions)
+
+func WithLoginHint(v string) Option {
+	return func(o *LoginOptions) {
+		o.LoginHint = v
+	}
+}
+
+func WithSelectAccount(v bool) Option {
+	return func(o *LoginOptions) {
+		o.SelectAccount = v
+	}
+}
+
+func ApplyOptions(opts []Option) LoginOptions {
+	var lo LoginOptions
+	for _, opt := range opts {
+		opt(&lo)
+	}
+	return lo
+}

--- a/proxy/internal/oidc/client.go
+++ b/proxy/internal/oidc/client.go
@@ -190,10 +190,10 @@ func (p *ProviderClient) RequestLogin(w http.ResponseWriter, req *http.Request, 
 	if p.cfg.HostedDomain != "" {
 		ep += "&hd=" + url.QueryEscape(p.cfg.HostedDomain)
 	}
-	if loginOptions.LoginHint != "" {
-		ep += "&login_hint=" + url.QueryEscape(loginOptions.LoginHint)
+	if hint := loginOptions.LoginHint(); hint != "" {
+		ep += "&login_hint=" + url.QueryEscape(hint)
 	}
-	if loginOptions.SelectAccount {
+	if loginOptions.SelectAccount() {
 		ep += "&prompt=select_account"
 	}
 	p.cm.SetNonce(w, nonceStr)

--- a/proxy/internal/passkeys/auth-template.html
+++ b/proxy/internal/passkeys/auth-template.html
@@ -37,7 +37,7 @@ a.button.big {
     <a class="button" href="{{.Self}}?get=RegisterNewID&redirect={{.Token}}">Register New Identity</a>
 {{- end }}
 {{- if ne .Mode "Login" }}
-    <a class="button" onclick="switchAccount({{.Self}}+'?get=Login&redirect={{.Token}}');">Switch Account</a>
+    <a class="button" onclick="switchAccount({{.Token}});">Switch Account</a>
 {{- end }}
   </div>
   <div id="message">

--- a/proxy/internal/passkeys/auth-template.html
+++ b/proxy/internal/passkeys/auth-template.html
@@ -45,19 +45,19 @@ a.button.big {
     <div class="big">🛂</div>
     <div>Authentication required to access</div>
     <div id="target"><a href="{{.URL}}">{{.DisplayURL}}</a></div>
-    <div><input id="loginid" placeholder="LOGIN ID" /></div>
+    <div><input id="loginid" placeholder="Email" /></div>
     <div><a class="button big" onclick="loginWithPasskey({{.Token}}, document.getElementById('loginid').value);">Continue</a></div>
 {{- end }}
 {{- if eq .Mode "RefreshID" }}
     <div>{{.Email}}</div>
-    <div><a class="button" onclick="loginWithPasskey({{.Token}});">Refresh ID</a></div>
+    <div><a class="button" onclick="loginWithPasskey({{.Token}}, {{.Email}});">Refresh ID</a></div>
 {{- end }}
 {{- if eq .Mode "RegisterNewID" }}
     <div>{{.Email}}</div>
   {{- if .IsAllowed }}
     {{- if .IsRegistered }}
     <div>Already Registered</div>
-    <div><a class="button big" onclick="loginWithPasskey({{.Token}});">Continue</a></div>
+    <div><a class="button big" onclick="loginWithPasskey({{.Token}}, {{.Email}});">Continue</a></div>
     {{- else }}
     <div><a class="button" onclick="registerPasskey({{.Token}});">Register This Identity</a></div>
     {{- end }}

--- a/proxy/internal/passkeys/auth-template.html
+++ b/proxy/internal/passkeys/auth-template.html
@@ -23,6 +23,11 @@ a.button.big {
 #message {
   width: fit-content;
 }
+#loginid {
+  font-size: 125%;
+  margin-top: 2rem;
+  width: 20rem;
+}
 </style>
 </head>
 <body>
@@ -40,7 +45,8 @@ a.button.big {
     <div class="big">🛂</div>
     <div>Authentication required to access</div>
     <div id="target"><a href="{{.URL}}">{{.DisplayURL}}</a></div>
-    <div><a class="button big" onclick="loginWithPasskey({{.Token}});">Continue</a></div>
+    <div><input id="loginid" placeholder="LOGIN ID" /></div>
+    <div><a class="button big" onclick="loginWithPasskey({{.Token}}, document.getElementById('loginid').value);">Continue</a></div>
 {{- end }}
 {{- if eq .Mode "RefreshID" }}
     <div>{{.Email}}</div>

--- a/proxy/internal/passkeys/auth-template.html
+++ b/proxy/internal/passkeys/auth-template.html
@@ -26,7 +26,7 @@ a.button.big {
 #loginid {
   font-size: 125%;
   margin-top: 2rem;
-  width: 20rem;
+  text-align: center;
 }
 </style>
 </head>

--- a/proxy/internal/passkeys/auth-template.html
+++ b/proxy/internal/passkeys/auth-template.html
@@ -45,7 +45,7 @@ a.button.big {
     <div class="big">🛂</div>
     <div>Authentication required to access</div>
     <div id="target"><a href="{{.URL}}">{{.DisplayURL}}</a></div>
-    <div><input id="loginid" placeholder="Email" /></div>
+    <div><input id="loginid" value="{{.Email}}" placeholder="Email" /></div>
     <div><a class="button big" onclick="loginWithPasskey({{.Token}}, document.getElementById('loginid').value);">Continue</a></div>
 {{- end }}
 {{- if eq .Mode "RefreshID" }}

--- a/proxy/internal/passkeys/manage-template.html
+++ b/proxy/internal/passkeys/manage-template.html
@@ -20,6 +20,7 @@
   gap: 0;
   padding: 0;
   border: solid 1px #606060;
+  background-color: white;
 }
 #keys > div {
   border: solid 1px #404040;

--- a/proxy/internal/passkeys/manager.go
+++ b/proxy/internal/passkeys/manager.go
@@ -271,7 +271,7 @@ func (m *Manager) HandleCallback(w http.ResponseWriter, req *http.Request) {
 	m.noncesMu.Unlock()
 
 	if ok {
-		token, _, err := m.cfg.TokenManager.URLToken(w, req, nData.origURL, map[string]any{"email": nData.opts.LoginHint})
+		token, _, err := m.cfg.TokenManager.URLToken(w, req, nData.origURL, map[string]any{"email": nData.opts.LoginHint()})
 		if err != nil {
 			m.cfg.Logger.Errorf("ERR %q: %v", nData.origURL, err)
 			http.Error(w, "internal error", http.StatusInternalServerError)

--- a/proxy/internal/passkeys/manager.go
+++ b/proxy/internal/passkeys/manager.go
@@ -942,6 +942,8 @@ func (m *Manager) assertionOptions(email string) (*AssertionOptions, error) {
 			}
 		}
 	} else if email != "" {
+		// Add fake credential ID to force the client to return an error
+		// like "No passkey registered for ..."
 		opts.AllowCredentials = append(opts.AllowCredentials, CredentialID{
 			Type:       "public-key",
 			ID:         Bytes{0xff},

--- a/proxy/internal/passkeys/testutils.go
+++ b/proxy/internal/passkeys/testutils.go
@@ -102,7 +102,7 @@ func (a *FakeAuthenticator) Create(options *AttestationOptions) (clientDataJSON,
 	}
 
 	authKey.uid = options.User.ID
-	authKey.rk = options.AuthenticatorSelection.RequireResidentKey
+	authKey.rk = options.AuthenticatorSelection.ResidentKey == "preferred" || options.AuthenticatorSelection.ResidentKey == "required"
 
 	authKey.id = make([]byte, 32)
 	if _, err := rand.Read(authKey.id); err != nil {

--- a/proxy/internal/passkeys/webauthn.go
+++ b/proxy/internal/passkeys/webauthn.go
@@ -86,8 +86,8 @@ type AttestationOptions struct {
 	AuthenticatorSelection struct {
 		// required, preferred, or discouraged
 		UserVerification string `json:"userVerification"`
-		// Whether we want discoverable credentials.
-		RequireResidentKey bool `json:"requireResidentKey"`
+		// required, preferred, or discouraged
+		ResidentKey string `json:"residentKey"`
 	} `json:"authenticatorSelection"`
 	// Extensions.
 	Extensions map[string]interface{} `json:"extensions,omitempty"`
@@ -112,7 +112,7 @@ func newAttestationOptions() (*AttestationOptions, error) {
 		Attestation: "none",
 	}
 	ao.AuthenticatorSelection.UserVerification = "required"
-	ao.AuthenticatorSelection.RequireResidentKey = true
+	ao.AuthenticatorSelection.ResidentKey = "preferred"
 
 	challenge := make([]byte, 32)
 	if _, err := rand.Read(challenge); err != nil {

--- a/proxy/internal/passkeys/webauthn.js
+++ b/proxy/internal/passkeys/webauthn.js
@@ -156,9 +156,7 @@ function loginWithPasskey(token, loginId) {
         window.location.reload();
       }
     } else if (r.result === 'refresh') {
-      if (window.confirm(r.email + ' ID must be refreshed')) {
-        window.location = r.url;
-      }
+      window.location = r.url;
     }
   })
   .catch(err => {

--- a/proxy/internal/saml/saml.go
+++ b/proxy/internal/saml/saml.go
@@ -43,6 +43,8 @@ import (
 
 	"github.com/beevik/etree"
 	dsig "github.com/russellhaering/goxmldsig"
+
+	"github.com/c2FmZQ/tlsproxy/proxy/internal/idp"
 )
 
 // http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf
@@ -103,7 +105,7 @@ func New(cfg Config, er EventRecorder, cm CookieManager) (*Provider, error) {
 	return p, nil
 }
 
-func (p *Provider) RequestLogin(w http.ResponseWriter, req *http.Request, origURL string) {
+func (p *Provider) RequestLogin(w http.ResponseWriter, req *http.Request, origURL string, opts ...idp.Option) {
 	ou, err := url.Parse(origURL)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/proxy/internal/tokenmanager/urltoken_test.go
+++ b/proxy/internal/tokenmanager/urltoken_test.go
@@ -45,7 +45,7 @@ func TestURLToken(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "https://example.com/foo/bar", nil)
 	w := httptest.NewRecorder()
-	tok, displayURL, err := tm.URLToken(w, req, req.URL)
+	tok, displayURL, err := tm.URLToken(w, req, req.URL, nil)
 	if err != nil {
 		t.Errorf("URLToken() err = %v", err)
 	}
@@ -54,13 +54,13 @@ func TestURLToken(t *testing.T) {
 	}
 
 	// Wrong session id
-	if _, err := tm.ValidateURLToken(w, req, tok); err == nil {
+	if _, _, err := tm.ValidateURLToken(w, req, tok); err == nil {
 		t.Fatal("ValidateURLToken should fail")
 	}
 
 	// Correct session id
 	req.Header.Set("cookie", w.Header().Get("set-cookie"))
-	u, err := tm.ValidateURLToken(w, req, tok)
+	u, _, err := tm.ValidateURLToken(w, req, tok)
 	if err != nil {
 		t.Errorf("ValidateURLToken err = %v", err)
 	}

--- a/proxy/metrics-template.html
+++ b/proxy/metrics-template.html
@@ -99,9 +99,13 @@ h1 {
 .table > div.row:nth-child(even) > div {
   background-color: #f8f8ff;
 }
-
 .group > div:nth-child(even) {
   background-color: #f8f8ff;
+}
+#sso {
+  position: absolute;
+  right: 1rem;
+  top: 1rem;
 }
 </style>
 <script>
@@ -160,6 +164,11 @@ function selectTab(target) {
 <body onload="init();">
 <div id="header">
 <h1>TLSPROXY {{.Version}}</h1>
+{{ if ne .Email "" }}
+<div id="sso">
+{{.Email}} <a href="/.sso/logout">Logout</a>
+</div>
+{{ end }}
 
 <div id="tabs"></div>
 </div>

--- a/proxy/metrics-template.html
+++ b/proxy/metrics-template.html
@@ -26,6 +26,25 @@ body {
 h1 {
   margin-left: 1rem;
 }
+a {
+  color: black;
+  cursor: pointer;
+}
+a.button {
+  text-decoration: none;
+  border: solid 1px black;
+  border-radius: 1rem;
+  background-color: lightgray;
+  color: black;
+  margin: 0;
+  padding: 0.5rem;
+  line-height: 2.25rem;
+  white-space: nowrap;
+  font-family: monospace;
+}
+a.button:hover {
+  background-color: darkgray;
+}
 #panels {
   background-color: white;
   margin-left: 1rem;
@@ -166,7 +185,7 @@ function selectTab(target) {
 <h1>TLSPROXY {{.Version}}</h1>
 {{ if ne .Email "" }}
 <div id="sso">
-{{.Email}} <a href="/.sso/logout">Logout</a>
+{{.Email}} <a href="/.sso/logout" class="button">Logout</a>
 </div>
 {{ end }}
 

--- a/proxy/metrics.go
+++ b/proxy/metrics.go
@@ -198,6 +198,7 @@ func (p *Proxy) metricsHandler(w http.ResponseWriter, req *http.Request) {
 	}
 
 	var data struct {
+		Email              string
 		Version            string
 		Metrics            []backendMetric
 		Events             []proxyEvent
@@ -211,6 +212,13 @@ func (p *Proxy) metricsHandler(w http.ResponseWriter, req *http.Request) {
 		BuildInfo          string
 		Config             string
 	}
+
+	if c := claimsFromCtx(req.Context()); c != nil {
+		if email, ok := c["email"].(string); ok {
+			data.Email = email
+		}
+	}
+
 	if info, ok := debug.ReadBuildInfo(); ok {
 		data.BuildInfo = info.String()
 		const v = "main.Version="

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -64,6 +64,7 @@ import (
 	"github.com/c2FmZQ/tlsproxy/certmanager"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/cookiemanager"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/counter"
+	"github.com/c2FmZQ/tlsproxy/proxy/internal/idp"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/netw"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/ocspcache"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/oidc"
@@ -159,7 +160,7 @@ func (er eventRecorder) Record(s string) {
 }
 
 type identityProvider interface {
-	RequestLogin(w http.ResponseWriter, req *http.Request, origURL string)
+	RequestLogin(w http.ResponseWriter, req *http.Request, origURL string, opts ...idp.Option)
 	HandleCallback(w http.ResponseWriter, req *http.Request)
 }
 

--- a/proxy/sso-status-template.html
+++ b/proxy/sso-status-template.html
@@ -28,6 +28,9 @@
 <body>
 <div id="buttons">
 {{ if len .Claims | ne 0 }}
+{{ if .Passkeys }}
+<a class="button" href="/.sso/passkeys">Passkeys</a>
+{{ end }}
 <a class="button" href="/.sso/logout?u={{.Token}}">Switch Account</a>
 <a class="button" href="/.sso/logout">Logout</a>
 {{ else }}

--- a/proxy/sso_test.go
+++ b/proxy/sso_test.go
@@ -451,7 +451,7 @@ func TestSSOEnforcePasskey(t *testing.T) {
 			if got, want := code, 200; got != want {
 				t.Errorf("Code = %v, want %v", got, want)
 			}
-			m = regexp.MustCompile(`loginWithPasskey\(&#34;(.*)&#34;\)`).FindStringSubmatch(body)
+			m = regexp.MustCompile(`loginWithPasskey\(&#34;(.*)&#34;,`).FindStringSubmatch(body)
 			if len(m) != 2 {
 				t.Fatalf("FindStringSubmatch: %v", m)
 			}


### PR DESCRIPTION
### Description

Expand passkeys to work without resident keys (aka discoverable credentials).

This change adds a UI component to the passkey login screen to capture the user's email address. When the email address is provided, the user can log in with any passkeys they have registered. If the email address is not provided, only passkeys with resident keys can be used.

### Type of change

* [ ] New feature
* [x] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)

### How is this change tested ?

* [x] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
