### PR TITLE
Add a SSH Certificate Authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # TLSPROXY Release Notes
 
+## next
+
+### :star2: New feature
+
+* Add a built-in certificate authority for SSH. It is enabled with the top-level `sshCertificateAuthorities` field in the config file.
+  * This CA issues SSH user certificates with the current user's email address as both `Key ID` and `Principal`. It only works when SSO is enabled.
+  * User authorization is done by adding a line like this to the user's `.ssh/authorized_keys` file:
+```
+cert-authority,principals="<email>" <CA's public key>
+```
+
 ## v0.13.2
 
 ### :wrench: Misc

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Overview of features:
 * [x] Support for the [PROXY protocol](https://github.com/haproxy/haproxy/blob/master/doc/proxy-protocol.txt) defined by HAProxy. (not on QUIC or HTTP/3 backends)
 * [x] TLS client authentication & authorization (when the proxy terminates the TLS connections).
 * [x] Built-in Certificate Authority for managing client and backend server TLS certificates.
+* [x] Built-in Certificate Authority for issuing SSH user certificates.
 * [x] User authentication with OpenID Connect, SAML, and/or passkeys (for HTTP and HTTPS connections). Optionally issue JSON Web Tokens (JWT) to authenticated users to use with the backend services and/or run a local OpenID Connect server for backend services.
 * [x] Access control by IP address.
 * [x] Routing based on Server Name Indication (SNI), with optional default route when SNI isn't used.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/c2FmZQ/tlsproxy
 
-go 1.23.1
+go 1.23.2
 
 require (
 	github.com/beevik/etree v1.4.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/c2FmZQ/tlsproxy
 
-go 1.23.2
+go 1.23.1
 
 require (
 	github.com/beevik/etree v1.4.1

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -158,6 +158,9 @@ type Config struct {
 	// PKI is a list of locally hosted and managed Certificate Authorities
 	// that can be used to authenticate TLS clients and backend servers.
 	PKI []*ConfigPKI `yaml:"pki,omitempty"`
+	// SSHCertificateAuthorities are locally hosted certificate authorities
+	// for SSH. Credentials are issued based on SSO data.
+	SSHCertificateAuthorities []*ConfigSSHCertificateAuthority `yaml:"sshCertificateAuthorities,omitempty"`
 	// TLSCertificates is a lists of TLS certificates that should be used
 	// instead of Let's Encrypt. If a certificate is needed but there is no
 	// match in this list, Let's Encrypt is used.
@@ -561,7 +564,7 @@ type ConfigPKI struct {
 	// Name is the name of the CA.
 	Name string `yaml:"name"`
 	// KeyType is type of cryptographic key to use with this CA. Valid
-	// values are: ecdsa-p224, ecdsa-p256, ecdsa-p394, ecdsa-p521, ed25519,
+	// values are: ecdsa-p224, ecdsa-p256, ecdsa-p384, ecdsa-p521, ed25519,
 	// rsa-2048, rsa-3072, and rsa-4096.
 	KeyType string `yaml:"keyType,omitempty"`
 	// IssuingCertificateURLs is a list of URLs that return the X509
@@ -581,6 +584,21 @@ type ConfigPKI struct {
 	// Admins is a list of users who are allowed to perform administrative
 	// tasks on the CA, e.g. revoke any certificate.
 	Admins []string `yaml:"admins"`
+}
+
+// ConfigSSHCertificateAuthority defines a certificate authority.
+type ConfigSSHCertificateAuthority struct {
+	// Name is the name of the CA.
+	Name string `yaml:"name"`
+	// KeyType is type of cryptographic key to use with this CA. Valid
+	// values are: ecdsa-p256, ecdsa-p384, ecdsa-p521, ed25519,
+	// rsa-2048, rsa-3072, and rsa-4096.
+	KeyType string `yaml:"keyType,omitempty"`
+	// PublicKeyEndpoint is the URL where the CA's public key is published.
+	PublicKeyEndpoint string `yaml:"publicKeyEndpoint"`
+	// CertificateEndpoint is the URL where certificates are issued. It
+	// receives a public key in a POST request and returns a certificate.
+	CertificateEndpoint string `yaml:"certificateEndpoint"`
 }
 
 // BackendSSO specifies the identity parameters to use for a backend.

--- a/proxy/internal/sshca/sshca.go
+++ b/proxy/internal/sshca/sshca.go
@@ -118,13 +118,8 @@ type SSHCA struct {
 }
 
 type certificateAuthority struct {
-	Name        string
-	PrivateKey  []byte
-	IssuedCerts []*certificate
-}
-
-type certificate struct {
-	Cert []byte
+	Name       string
+	PrivateKey []byte
 }
 
 func (ca *SSHCA) open() (func(commit bool, errp *error) error, error) {

--- a/proxy/internal/sshca/sshca.go
+++ b/proxy/internal/sshca/sshca.go
@@ -1,0 +1,336 @@
+// MIT License
+//
+// Copyright (c) 2024 TTBT Enterprises LLC
+// Copyright (c) 2024 Robin Thellend <rthellend@rthellend.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Package sshca implements a simple certificate authority for SSH.
+package sshca
+
+import (
+	"context"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/c2FmZQ/storage"
+	"github.com/c2FmZQ/tpm"
+	jwt "github.com/golang-jwt/jwt/v5"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/c2FmZQ/tlsproxy/proxy/internal/pki/keys"
+)
+
+const (
+	issuedCertsLifetime = 1 * time.Hour
+)
+
+type defaultLogger struct{}
+
+func (defaultLogger) Errorf(format string, args ...any) {
+	log.Printf(format, args...)
+}
+
+// Options are used to configure the CA.
+type Options struct {
+	// Name is the name of the CA.
+	Name string `yaml:"name"`
+	// KeyType is type of cryptographic key to use with this CA. Valid
+	// values are: ecdsa-p256, ecdsa-p384, ecdsa-p521, ed25519,
+	// rsa-2048, rsa-3072, and rsa-4096.
+	KeyType string `yaml:"keyType,omitempty"`
+	// PublicKeyEndpoint is the URL where the CA's public key is published.
+	PublicKeyEndpoint string `yaml:"publicKeyEndpoint"`
+	// CertificateEndpoint is the URL where certificates are issued. It
+	// receives a public key in a POST request and returns a certificate.
+	CertificateEndpoint string `yaml:"certificateEndpoint"`
+	// TPM is used for hardware-backed keys.
+	TPM *tpm.TPM
+	// Store is used to store the PKI manager's data.
+	Store *storage.Storage
+	// EventRecorder is used to record events.
+	EventRecorder interface {
+		Record(string)
+	}
+	Logger interface {
+		Errorf(format string, args ...any)
+	}
+	// ClaimsFromCtx returns jwt claims for the current user.
+	ClaimsFromCtx func(context.Context) jwt.MapClaims
+}
+
+// New returns a new initialized CA.
+func New(opts Options) (*SSHCA, error) {
+	if opts.Logger == nil {
+		opts.Logger = defaultLogger{}
+	}
+	ca := &SSHCA{
+		opts:   opts,
+		caFile: "sshca-" + url.PathEscape(opts.Name),
+	}
+	if ca.opts.KeyType == "" {
+		ca.opts.KeyType = "ecdsa-p256"
+	}
+	if ca.opts.ClaimsFromCtx == nil {
+		return nil, errors.New("ClaimsFromCtx must be set")
+	}
+	ca.opts.Store.CreateEmptyFile(ca.caFile, &certificateAuthority{})
+	if err := ca.initCA(); err != nil {
+		return nil, err
+	}
+	return ca, nil
+}
+
+// SSHCA implements a simple certificate authority for SSH keys.
+type SSHCA struct {
+	opts   Options
+	caFile string
+	mu     sync.Mutex
+	db     *certificateAuthority
+	signer ssh.Signer
+}
+
+type certificateAuthority struct {
+	Name        string
+	PrivateKey  []byte
+	IssuedCerts []*certificate
+}
+
+type certificate struct {
+	Cert []byte
+}
+
+func (ca *SSHCA) open() (func(commit bool, errp *error) error, error) {
+	commit, err := ca.opts.Store.OpenForUpdate(ca.caFile, &ca.db)
+	if err != nil {
+		return nil, err
+	}
+	return commit, nil
+}
+
+func (ca *SSHCA) initCA() (retErr error) {
+	ca.mu.Lock()
+	defer ca.mu.Unlock()
+
+	commit, err := ca.open()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		commit(false, &retErr)
+		if retErr == storage.ErrRolledBack {
+			retErr = nil
+		}
+	}()
+	var changed bool
+	if ca.db == nil {
+		ca.db = &certificateAuthority{
+			Name: ca.opts.Name,
+		}
+		changed = true
+	}
+
+	if len(ca.db.PrivateKey) == 0 {
+		_, keyBytes, err := ca.generateKey(ca.opts.KeyType)
+		if err != nil {
+			return err
+		}
+		ca.db.PrivateKey = keyBytes
+		changed = true
+	}
+
+	key, err := ca.parseKeyBytes(ca.db.PrivateKey)
+	if err != nil {
+		return err
+	}
+	signer, err := ssh.NewSignerFromKey(key)
+	if err != nil {
+		return err
+	}
+	ca.signer = signer
+
+	return commit(changed, nil)
+}
+
+func (ca *SSHCA) generateKey(keyType string) (any, []byte, error) {
+	if ca.opts.TPM != nil {
+		switch kt := strings.ToLower(keyType); kt {
+		case "ecdsa-p256", "ecdsa-p384", "ecdsa-p521":
+			var crv elliptic.Curve
+			switch kt {
+			case "ecdsa-p256":
+				crv = elliptic.P256()
+			case "ecdsa-p384":
+				crv = elliptic.P384()
+			case "ecdsa-p521":
+				crv = elliptic.P521()
+			}
+			key, err := ca.opts.TPM.CreateKey(tpm.WithECC(crv))
+			if err != nil {
+				return nil, nil, err
+			}
+			keyBytes, err := key.Marshal()
+			if err != nil {
+				return nil, nil, err
+			}
+			return key, keyBytes, nil
+
+		case "rsa-2048", "rsa-3072", "rsa-4096", "rsa-8192":
+			var bits int
+			switch kt {
+			case "rsa-2048":
+				bits = 2048
+			case "rsa-3072":
+				bits = 3072
+			case "rsa-4096":
+				bits = 4096
+			case "rsa-8192":
+				bits = 8192
+			}
+			key, err := ca.opts.TPM.CreateKey(tpm.WithRSA(bits))
+			if err != nil {
+				return nil, nil, err
+			}
+			keyBytes, err := key.Marshal()
+			if err != nil {
+				return nil, nil, err
+			}
+			return key, keyBytes, nil
+
+		default:
+			return nil, nil, fmt.Errorf("unexpected key type: %q", keyType)
+		}
+	}
+	key, err := keys.GenerateKey(keyType)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyBytes, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("x509.MarshalPKCS8PrivateKey: %v", err)
+	}
+	return key, keyBytes, nil
+}
+
+func (ca *SSHCA) parseKeyBytes(b []byte) (any, error) {
+	if ca.opts.TPM != nil {
+		return ca.opts.TPM.UnmarshalKey(b)
+	}
+	return x509.ParsePKCS8PrivateKey(b)
+}
+
+func (ca *SSHCA) ServePublicKey(w http.ResponseWriter, req *http.Request) {
+	ca.mu.Lock()
+	defer ca.mu.Unlock()
+	if ca.signer == nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	out := ssh.MarshalAuthorizedKey(ca.signer.PublicKey())
+	w.Header().Set("cache-control", "public, max-age=86400")
+	w.Header().Set("content-type", "text/plain")
+	w.Header().Set("content-length", fmt.Sprintf("%d", len(out)))
+	w.Write(out)
+}
+
+func (ca *SSHCA) ServeCertificate(w http.ResponseWriter, req *http.Request) {
+	ca.mu.Lock()
+	defer ca.mu.Unlock()
+	if ca.signer == nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	claims := ca.opts.ClaimsFromCtx(req.Context())
+	if claims == nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	email, ok := claims["email"].(string)
+	if !ok || email == "" {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
+	if req.Method != http.MethodPost {
+		ca.opts.Logger.Errorf("ERR method: %v", req.Method)
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if v := req.Header.Get("x-csrf-check"); v != "1" {
+		ca.opts.Logger.Errorf("ERR x-csrf-check: %v", v)
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if ct := req.Header.Get("content-type"); ct != "text/plain" {
+		ca.opts.Logger.Errorf("ERR content-type: %v", ct)
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	defer req.Body.Close()
+	body, err := io.ReadAll(&io.LimitedReader{R: req.Body, N: 102400})
+	if err != nil {
+		ca.opts.Logger.Errorf("ERR body: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	pub, _, _, _, err := ssh.ParseAuthorizedKey(body)
+	if err != nil {
+		ca.opts.Logger.Errorf("ERR body: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	now := time.Now().UTC()
+	cert := &ssh.Certificate{
+		Key:             pub,
+		CertType:        ssh.UserCert,
+		KeyId:           email,
+		ValidPrincipals: []string{email},
+		ValidAfter:      uint64(now.Add(-5 * time.Minute).Unix()),
+		ValidBefore:     uint64(now.Add(issuedCertsLifetime).Unix()),
+		Permissions: ssh.Permissions{
+			Extensions: map[string]string{
+				"permit-X11-forwarding":   "",
+				"permit-agent-forwarding": "",
+				"permit-port-forwarding":  "",
+				"permit-pty":              "",
+				"permit-user-rc":          "",
+			},
+		},
+	}
+	if err := cert.SignCert(rand.Reader, ca.signer); err != nil {
+		ca.opts.Logger.Errorf("ERR SignCert: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	out := ssh.MarshalAuthorizedKey(cert)
+	w.Header().Set("cache-control", "no-store")
+	w.Header().Set("content-type", "text/plain")
+	w.Header().Set("content-length", fmt.Sprintf("%d", len(out)))
+	w.Write(out)
+}

--- a/proxy/internal/sshca/sshca.go
+++ b/proxy/internal/sshca/sshca.go
@@ -336,7 +336,9 @@ func (ca *SSHCA) ServeCertificate(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
-	ca.opts.EventRecorder.Record("ssh certificate issued")
+	if ca.opts.EventRecorder != nil {
+		ca.opts.EventRecorder.Record("ssh certificate issued")
+	}
 
 	out := ssh.MarshalAuthorizedKey(cert)
 	w.Header().Set("cache-control", "no-store")

--- a/proxy/internal/sshca/sshca.go
+++ b/proxy/internal/sshca/sshca.go
@@ -49,7 +49,7 @@ import (
 )
 
 const (
-	issuedCertsLifetime = 1 * time.Hour
+	issuedCertsLifetime = 10 * time.Minute
 )
 
 type defaultLogger struct{}
@@ -336,6 +336,8 @@ func (ca *SSHCA) ServeCertificate(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
+	ca.opts.EventRecorder.Record("ssh certificate issued")
+
 	out := ssh.MarshalAuthorizedKey(cert)
 	w.Header().Set("cache-control", "no-store")
 	w.Header().Set("content-type", "text/plain")

--- a/proxy/internal/sshca/sshca_test.go
+++ b/proxy/internal/sshca/sshca_test.go
@@ -1,0 +1,166 @@
+// MIT License
+//
+// Copyright (c) 2024 TTBT Enterprises LLC
+// Copyright (c) 2024 Robin Thellend <rthellend@rthellend.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package sshca
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/c2FmZQ/storage"
+	"github.com/c2FmZQ/storage/crypto"
+	"github.com/c2FmZQ/tpm"
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/google/go-tpm-tools/simulator"
+	"golang.org/x/crypto/ssh"
+)
+
+func newCA(t *testing.T, tpm *tpm.TPM) *SSHCA {
+	dir := t.TempDir()
+	mk, err := crypto.CreateAESMasterKeyForTest()
+	if err != nil {
+		t.Fatalf("crypto.CreateMasterKey: %v", err)
+	}
+	opts := Options{
+		Name:                "sshca-test",
+		PublicKeyEndpoint:   "https://ssh.example.com/ca",
+		CertificateEndpoint: "https://ssh.example.com/cert",
+		Store:               storage.New(dir, mk),
+		TPM:                 tpm,
+		ClaimsFromCtx: func(context.Context) jwt.MapClaims {
+			return jwt.MapClaims{
+				"email": "alice@example.com",
+			}
+		},
+	}
+	ca, err := New(opts)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return ca
+}
+
+func TestNewSSHCA(t *testing.T) {
+	ca := newCA(t, nil)
+	if ca.db == nil {
+		t.Fatal("ssh.example.com doesn't exist")
+	}
+	if ca.db.PrivateKey == nil {
+		t.Fatal("ca key is not set")
+	}
+}
+
+func TestCertificate(t *testing.T) {
+	rwc, err := simulator.Get()
+	if err != nil {
+		t.Fatalf("simulator.Get: %v", err)
+	}
+	tpmSim, err := tpm.New(tpm.WithTPM(rwc))
+	if err != nil {
+		t.Fatalf("tpm.New: %v", err)
+	}
+	for _, tc := range []struct {
+		name string
+		tpm  *tpm.TPM
+	}{
+		{"Without TPM", nil},
+		{"With TPM", tpmSim},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newCA(t, tc.tpm)
+			mux := http.NewServeMux()
+			mux.HandleFunc("/ca", m.ServePublicKey)
+			mux.HandleFunc("/cert", m.ServeCertificate)
+			server := httptest.NewServer(mux)
+			defer server.Close()
+			resp, err := http.Get(server.URL + "/ca")
+			if err != nil {
+				t.Fatalf("Get(/ca): %v", err)
+			}
+			defer resp.Body.Close()
+			caKeyBytes, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("key body: %v", err)
+			}
+			caKey, _, _, _, err := ssh.ParseAuthorizedKey(caKeyBytes)
+			if err != nil {
+				t.Fatalf("ssh.ParseAuthorizedKey: %v", err)
+			}
+
+			pub, _, err := ed25519.GenerateKey(rand.Reader)
+			if err != nil {
+				t.Fatalf("ed25519.GenerateKey: %v", err)
+			}
+			sshPub, err := ssh.NewPublicKey(pub)
+			if err != nil {
+				t.Fatalf("ssh.NewPublicKey: %v", err)
+			}
+
+			req, err := http.NewRequest("POST", server.URL+"/cert", bytes.NewReader(ssh.MarshalAuthorizedKey(sshPub)))
+			if err != nil {
+				t.Fatalf("http.NewRequest: %v", err)
+			}
+			req.Header.Set("x-csrf-check", "1")
+			req.Header.Set("content-type", "text/plain")
+			if resp, err = http.DefaultClient.Do(req); err != nil {
+				t.Fatalf("Post(/cert): %v", err)
+			}
+			defer resp.Body.Close()
+			certBytes, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("cert body: %v", err)
+			}
+
+			c, _, _, _, err := ssh.ParseAuthorizedKey(certBytes)
+			if err != nil {
+				t.Fatalf("ssh.ParseAuthorizedKey: %v", err)
+			}
+			cert, ok := c.(*ssh.Certificate)
+			if !ok {
+				t.Fatalf("Parsed cert is %T", c)
+			}
+
+			if got, want := cert.SignatureKey.Marshal(), caKey.Marshal(); !bytes.Equal(got, want) {
+				t.Fatalf("cert.SignatureKey doesn't match caKey")
+			}
+			if got, want := cert.Key.Marshal(), sshPub.Marshal(); !bytes.Equal(got, want) {
+				t.Fatalf("cert.Key doesn't match sshKey")
+			}
+			if got, want := cert.KeyId, "alice@example.com"; got != want {
+				t.Fatalf("cert.KeyId = %q, want %q", got, want)
+			}
+			if len(cert.ValidPrincipals) != 1 {
+				t.Fatalf("cert.Principals = %v", cert.ValidPrincipals)
+			}
+			if got, want := cert.ValidPrincipals[0], "alice@example.com"; got != want {
+				t.Fatalf("cert.ValidPrincipals[0] = %q, want %q", got, want)
+			}
+		})
+	}
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -809,16 +809,19 @@ func (p *Proxy) Reconfigure(cfg *Config) error {
 		if err != nil {
 			return err
 		}
-		addLocalHandler(localHandler{
-			desc:      fmt.Sprintf("SSH CA Public Key (%s)", pp.Name),
-			handler:   logHandler(http.HandlerFunc(ca.ServePublicKey)),
-			ssoBypass: true,
-		}, pp.PublicKeyEndpoint)
-		addLocalHandler(localHandler{
-			desc:      fmt.Sprintf("SSH CA Certificate (%s)", pp.Name),
-			handler:   logHandler(http.HandlerFunc(ca.ServeCertificate)),
-			ssoBypass: false,
-		}, pp.CertificateEndpoint)
+		if pp.PublicKeyEndpoint != "" {
+			addLocalHandler(localHandler{
+				desc:      fmt.Sprintf("SSH CA Public Key (%s)", pp.Name),
+				handler:   logHandler(http.HandlerFunc(ca.ServePublicKey)),
+				ssoBypass: true,
+			}, pp.PublicKeyEndpoint)
+		}
+		if pp.CertificateEndpoint != "" {
+			addLocalHandler(localHandler{
+				desc:    fmt.Sprintf("SSH CA Certificate (%s)", pp.Name),
+				handler: logHandler(http.HandlerFunc(ca.ServeCertificate)),
+			}, pp.CertificateEndpoint)
+		}
 	}
 
 	if len(cfg.WebSockets) > 0 && p.wsUpgrader == nil {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -72,6 +72,7 @@ import (
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/passkeys"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/pki"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/saml"
+	"github.com/c2FmZQ/tlsproxy/proxy/internal/sshca"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/tokenmanager"
 )
 
@@ -793,6 +794,33 @@ func (p *Proxy) Reconfigure(cfg *Config) error {
 			}, pp.Endpoint)
 		}
 	}
+	for _, pp := range cfg.SSHCertificateAuthorities {
+		opts := sshca.Options{
+			Name:                pp.Name,
+			KeyType:             pp.KeyType,
+			PublicKeyEndpoint:   pp.PublicKeyEndpoint,
+			CertificateEndpoint: pp.CertificateEndpoint,
+			TPM:                 p.tpm,
+			Store:               p.store,
+			EventRecorder:       er,
+			ClaimsFromCtx:       claimsFromCtx,
+		}
+		ca, err := sshca.New(opts)
+		if err != nil {
+			return err
+		}
+		addLocalHandler(localHandler{
+			desc:      fmt.Sprintf("SSH CA Public Key (%s)", pp.Name),
+			handler:   logHandler(http.HandlerFunc(ca.ServePublicKey)),
+			ssoBypass: true,
+		}, pp.PublicKeyEndpoint)
+		addLocalHandler(localHandler{
+			desc:      fmt.Sprintf("SSH CA Certificate (%s)", pp.Name),
+			handler:   logHandler(http.HandlerFunc(ca.ServeCertificate)),
+			ssoBypass: false,
+		}, pp.CertificateEndpoint)
+	}
+
 	if len(cfg.WebSockets) > 0 && p.wsUpgrader == nil {
 		p.wsUpgrader = newWebSocketUpgrader()
 	}


### PR DESCRIPTION
### Description

This authority issues SSH user certificates with the user's email address as Key ID and Principal.

### Type of change

* [x] New feature
* [ ] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)


### How is this change tested ?

* [x] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
