### PR TITLE
Disable http2 extended connect

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -102,6 +102,18 @@ var (
 	errAccessDenied = errors.New("access denied")
 )
 
+func init() {
+	// https://github.com/golang/go/issues/71128
+	v := os.Getenv("GODEBUG")
+	if len(v) > 0 {
+		if strings.Contains(v, "http2xconnect=0") {
+			return
+		}
+		v += ","
+	}
+	os.Setenv("GODEBUG", v+"http2xconnect=0")
+}
+
 // Proxy receives TLS connections and forwards them to the configured
 // backends.
 type Proxy struct {


### PR DESCRIPTION
### Description

Disable http2 extended connect.

http2 extended connect was added in x/net 0.33, and go1.24rc1. It breaks websockets.

### Type of change

* [ ] New feature
* [ ] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [x] Other (please explain)

### How is this change tested ?

* [ ] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed

### Links to related issues

https://github.com/golang/go/issues/71128