### PR TITLE
Fix regression in backend name resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # TLSPROXY Release Notes
 
+## next
+
+### :wrench: Bug fix
+
+* Fix [issue 195](https://github.com/c2FmZQ/tlsproxy/issues/195).
+  * Use the default GO resolver by default to resolve backend addresses.
+  * Add new config option `UseDoH` to enable DNS-over-HTTPS as needed.
+
+### :wrench: Misc
+
+* Update go dependencies:
+  * upgraded github.com/c2FmZQ/ech v0.3.2 => v0.3.4
+
 ## v0.15.2
 
 ### :star: Feature improvement

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 require (
 	github.com/beevik/etree v1.5.0
-	github.com/c2FmZQ/ech v0.3.2
+	github.com/c2FmZQ/ech v0.3.4
 	github.com/c2FmZQ/ech/publish v0.1.1
 	github.com/c2FmZQ/ech/quic v0.3.0
 	github.com/c2FmZQ/storage v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
 github.com/beevik/etree v1.5.0 h1:iaQZFSDS+3kYZiGoc9uKeOkUY3nYMXOKLl6KIJxiJWs=
 github.com/beevik/etree v1.5.0/go.mod h1:gPNJNaBGVZ9AwsidazFZyygnd+0pAU38N4D+WemwKNs=
-github.com/c2FmZQ/ech v0.3.2 h1:QcOIGYczZ9LZ6FrwB7D49VVBURJGGjds/AeVKIc4Iew=
-github.com/c2FmZQ/ech v0.3.2/go.mod h1:l27DtuP6rSjRMYvneEc6FBK5gnuOkOQIbY58PB38DWo=
+github.com/c2FmZQ/ech v0.3.4 h1:1+YnNolbLCzEEUT2kpws9RAUCBtBPo891HqBaoKyzc4=
+github.com/c2FmZQ/ech v0.3.4/go.mod h1:l27DtuP6rSjRMYvneEc6FBK5gnuOkOQIbY58PB38DWo=
 github.com/c2FmZQ/ech/publish v0.1.1 h1:NRrLalLZfQgEET3cqsiaR2Y5oB2V/do5ErAQ2boWykI=
 github.com/c2FmZQ/ech/publish v0.1.1/go.mod h1:sUZW3FxGqL6optTBmmFgtwekpC86RkOC261wA/HUcK4=
 github.com/c2FmZQ/ech/quic v0.3.0 h1:VAus+2qNBbT9ceWabJXu4cv16UtQaX184OI/xcryxGg=

--- a/proxy/backend.go
+++ b/proxy/backend.go
@@ -133,6 +133,7 @@ func (be *Backend) dial(ctx context.Context, protos ...string) (net.Conn, error)
 	}
 
 	dialer := ech.Dialer[net.Conn]{
+		Resolver: be.resolver,
 		DialFunc: func(ctx context.Context, network, addr string, tc *tls.Config) (net.Conn, error) {
 			if mode == ModeQUIC {
 				return be.dialQUICStream(ctx, addr, tc)


### PR DESCRIPTION
### Description

Fix https://github.com/c2FmZQ/tlsproxy/issues/195:
  * Use the default GO resolver by default to resolve backend addresses.
  * Add new config option `UseDoH` to enable DNS-over-HTTPS as needed.

### Type of change

* [ ] New feature
* [ ] Feature improvement
* [x] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)

### How is this change tested ?

* [ ] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
