### PR TITLE
Add backend ECH config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # TLSPROXY Release Notes
 
+## next
+
+### :star: Feature improvement
+
+* Add backend config options to facilitate enabling Encrypted Client Hello (ECH) between tlsproxy and its backends. See `ForwardECH` in proxy/config.go.
+
 ## v0.15.4
 
 ### :wrench: Misc


### PR DESCRIPTION
### Description

Add backend config options to facilitate enabling Encrypted Client Hello (ECH) between tlsproxy and its backends. See `ForwardECH` in proxy/config.go.

### Type of change

* [ ] New feature
* [x] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)

### How is this change tested ?

* [x] Unit tests
* [ ] Manual tests (explain)
* [ ] Tests are not needed
