### PR TITLE
Enable OCSP-stapling only when supported by CA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # TLSPROXY Release Notes
 
+## next
+
+### :wrench: Bug Fix
+
+* [Let's Encrypt is removing support for OCSP](https://letsencrypt.org/2024/12/05/ending-ocsp/). This change broke some assumptions in TLSPROXY which resulted in failed requests and some crashes. This release fixes that problem. OCSP stapling will only be enabled when the certificate authority supports it.
+
 ## v0.15.9
 
 ### :wrench: Misc

--- a/proxy/internal/ocspcache/ocsp.go
+++ b/proxy/internal/ocspcache/ocsp.go
@@ -192,6 +192,9 @@ func certHash(b []byte) string {
 }
 
 func (c *OCSPCache) Response(ctx context.Context, cert, issuer *x509.Certificate, margin time.Duration) (*ocsp.Response, error) {
+	if len(cert.OCSPServer) == 0 {
+		return nil, nil
+	}
 	hash := certHash(cert.Raw)
 	if resp, ok := c.cache.Get(hash); ok && time.Now().Add(margin).Before(resp.NextUpdate) {
 		return resp, nil


### PR DESCRIPTION
### Description

Let's Encrypt is removing support for OCSP. This broke some assumptions in TLSPROXY which resulted in failed requests and some crashes. This change fixes the problem. OCSP stapling will only be enabled when the certificate authority supports it.

### Type of change

* [ ] New feature
* [ ] Feature improvement
* [x] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)

### How is this change tested ?

* [ ] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed

### Links to related issues

https://letsencrypt.org/2024/12/05/ending-ocsp/