### PR TITLE
Allow the config file to be split into multiple files/directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## next
 
+### :star2: New feature
+
+* The config file can now be split across multiple files or directories with the 'include' directive, e.g.
+  ```
+  include:
+    - "conf/*.yaml"
+  ```
+
 ### :wrench: Misc
 
 * Update go dependencies:

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func main() {
 		if *passphraseFlag == "" {
 			log.Fatal("--passphrase or $TLSPROXY_PASSPHRASE must be set")
 		}
-		if !cfg.AcceptTOS {
+		if cfg.AcceptTOS == nil || !*cfg.AcceptTOS {
 			log.Fatal("acceptTOS must be set to true in the config file")
 		}
 		p, err = proxy.New(cfg, []byte(*passphraseFlag))

--- a/proxy/backend-sso_test.go
+++ b/proxy/backend-sso_test.go
@@ -202,10 +202,10 @@ func TestEnforceSSOPolicy(t *testing.T) {
 func newBackendSSOTestProxy(t *testing.T) *Proxy {
 	return newTestProxy(
 		&Config{
-			HTTPAddr: "localhost:0",
-			TLSAddr:  "localhost:0",
-			CacheDir: t.TempDir(),
-			MaxOpen:  100,
+			HTTPAddr: newPtr("localhost:0"),
+			TLSAddr:  newPtr("localhost:0"),
+			CacheDir: newPtr(t.TempDir()),
+			MaxOpen:  newPtr(100),
 			OIDCProviders: []*ConfigOIDC{
 				{
 					Name:          "test-idp",

--- a/proxy/ech_test.go
+++ b/proxy/ech_test.go
@@ -53,11 +53,11 @@ func TestECH(t *testing.T) {
 	}
 	proxy := newTestProxy(
 		&Config{
-			HTTPAddr: "localhost:0",
-			TLSAddr:  "localhost:0",
+			HTTPAddr: newPtr("localhost:0"),
+			TLSAddr:  newPtr("localhost:0"),
 			ECH:      &ECH{PublicName: "https.example.com"},
-			CacheDir: t.TempDir(),
-			MaxOpen:  100,
+			CacheDir: newPtr(t.TempDir()),
+			MaxOpen:  newPtr(100),
 		},
 		extCA,
 	)
@@ -83,7 +83,7 @@ func TestECH(t *testing.T) {
 
 	cfg := &Config{
 		ECH:     &ECH{PublicName: "https.example.com"},
-		MaxOpen: 100,
+		MaxOpen: newPtr(100),
 		Backends: []*Backend{
 			{
 				ServerNames: []string{

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -76,10 +76,10 @@ func TestProxyBackends(t *testing.T) {
 
 	proxy := newTestProxy(
 		&Config{
-			HTTPAddr: "localhost:0",
-			TLSAddr:  "localhost:0",
-			CacheDir: t.TempDir(),
-			MaxOpen:  100,
+			HTTPAddr: newPtr("localhost:0"),
+			TLSAddr:  newPtr("localhost:0"),
+			CacheDir: newPtr(t.TempDir()),
+			MaxOpen:  newPtr(100),
 			PKI: []*ConfigPKI{
 				{Name: "TEST CA"},
 			},
@@ -121,11 +121,11 @@ func TestProxyBackends(t *testing.T) {
 	h2Value := "h2"
 
 	cfg := &Config{
-		MaxOpen: 100,
+		MaxOpen: newPtr(100),
 		PKI: []*ConfigPKI{
 			{Name: "TEST CA"},
 		},
-		DefaultServerName: "http.example.com",
+		DefaultServerName: newPtr("http.example.com"),
 		Backends: []*Backend{
 			// Plaintext backends.
 			{
@@ -447,10 +447,10 @@ func TestAuthnAuthz(t *testing.T) {
 		t.Fatalf("certmanager.New: %v", err)
 	}
 	cfg := &Config{
-		HTTPAddr: "localhost:0",
-		TLSAddr:  "localhost:0",
-		CacheDir: t.TempDir(),
-		MaxOpen:  100,
+		HTTPAddr: newPtr("localhost:0"),
+		TLSAddr:  newPtr("localhost:0"),
+		CacheDir: newPtr(t.TempDir()),
+		MaxOpen:  newPtr(100),
 		PKI: []*ConfigPKI{
 			{Name: "TEST CA"},
 		},
@@ -644,10 +644,10 @@ func TestLocalTLSCerts(t *testing.T) {
 
 	proxy := newTestProxy(
 		&Config{
-			HTTPAddr: "localhost:0",
-			TLSAddr:  "localhost:0",
-			CacheDir: t.TempDir(),
-			MaxOpen:  100,
+			HTTPAddr: newPtr("localhost:0"),
+			TLSAddr:  newPtr("localhost:0"),
+			CacheDir: newPtr(t.TempDir()),
+			MaxOpen:  newPtr(100),
 			TLSCertificates: []*TLSCertificate{
 				{
 					ServerNames: []string{"http.example.com"},
@@ -734,10 +734,10 @@ func TestConcurrency(t *testing.T) {
 
 	proxy := newTestProxy(
 		&Config{
-			HTTPAddr: "localhost:0",
-			TLSAddr:  "localhost:0",
-			CacheDir: t.TempDir(),
-			MaxOpen:  5000,
+			HTTPAddr: newPtr("localhost:0"),
+			TLSAddr:  newPtr("localhost:0"),
+			CacheDir: newPtr(t.TempDir()),
+			MaxOpen:  newPtr(5000),
 			Backends: []*Backend{
 				{
 					ServerNames: []string{
@@ -878,10 +878,10 @@ func TestBackendHTTPHeaders(t *testing.T) {
 
 	proxy := newTestProxy(
 		&Config{
-			HTTPAddr: "localhost:0",
-			TLSAddr:  "localhost:0",
-			CacheDir: t.TempDir(),
-			MaxOpen:  100,
+			HTTPAddr: newPtr("localhost:0"),
+			TLSAddr:  newPtr("localhost:0"),
+			CacheDir: newPtr(t.TempDir()),
+			MaxOpen:  newPtr(100),
 			Backends: []*Backend{
 				// HTTP
 				{
@@ -931,10 +931,10 @@ func TestBandwidthLimit(t *testing.T) {
 
 	proxy := newTestProxy(
 		&Config{
-			HTTPAddr: "localhost:0",
-			TLSAddr:  "localhost:0",
-			CacheDir: t.TempDir(),
-			MaxOpen:  2000,
+			HTTPAddr: newPtr("localhost:0"),
+			TLSAddr:  newPtr("localhost:0"),
+			CacheDir: newPtr(t.TempDir()),
+			MaxOpen:  newPtr(2000),
 			BWLimits: []*BWLimit{
 				{
 					Name:    "slowingress",
@@ -1035,10 +1035,10 @@ func TestIncomingProxyProto(t *testing.T) {
 
 	proxy := newTestProxy(
 		&Config{
-			HTTPAddr: "localhost:0",
-			TLSAddr:  "localhost:0",
-			CacheDir: t.TempDir(),
-			MaxOpen:  100,
+			HTTPAddr: newPtr("localhost:0"),
+			TLSAddr:  newPtr("localhost:0"),
+			CacheDir: newPtr(t.TempDir()),
+			MaxOpen:  newPtr(100),
 			AcceptProxyHeaderFrom: []string{
 				"127.0.0.1/32",
 				"::1/128",
@@ -1083,10 +1083,10 @@ func TestProxyProtoIsolation(t *testing.T) {
 
 	proxy := newTestProxy(
 		&Config{
-			HTTPAddr: "localhost:0",
-			TLSAddr:  "localhost:0",
-			CacheDir: t.TempDir(),
-			MaxOpen:  100,
+			HTTPAddr: newPtr("localhost:0"),
+			TLSAddr:  newPtr("localhost:0"),
+			CacheDir: newPtr(t.TempDir()),
+			MaxOpen:  newPtr(100),
 			Backends: []*Backend{
 				{
 					ServerNames: []string{
@@ -1130,11 +1130,11 @@ func TestProxyTPM(t *testing.T) {
 	be1 := newHTTPServer(t, ctx, "backend1", nil)
 	dir := t.TempDir()
 	cfg := &Config{
-		HTTPAddr: "localhost:0",
-		TLSAddr:  "localhost:0",
-		CacheDir: dir,
-		HWBacked: true,
-		MaxOpen:  100,
+		HTTPAddr: newPtr("localhost:0"),
+		TLSAddr:  newPtr("localhost:0"),
+		CacheDir: newPtr(dir),
+		HWBacked: newPtr(true),
+		MaxOpen:  newPtr(100),
 		Backends: []*Backend{
 			{
 				ServerNames: []string{
@@ -1166,10 +1166,10 @@ func TestProxyTPM(t *testing.T) {
 
 func TestCheckIP(t *testing.T) {
 	cfg := &Config{
-		HTTPAddr: "localhost:0",
-		TLSAddr:  "localhost:0",
-		CacheDir: t.TempDir(),
-		MaxOpen:  100,
+		HTTPAddr: newPtr("localhost:0"),
+		TLSAddr:  newPtr("localhost:0"),
+		CacheDir: newPtr(t.TempDir()),
+		MaxOpen:  newPtr(100),
 		Backends: []*Backend{
 			{
 				ServerNames: []string{"example.com"},
@@ -1261,7 +1261,7 @@ func newTestProxy(cfg *Config, cm *certmanager.CertManager) *Proxy {
 		crypto.WithStrictWipe(false),
 	}
 	var tpmSim *tpm.TPM
-	if cfg.HWBacked {
+	if cfg.HWBacked != nil && *cfg.HWBacked {
 		rwc, err := simulator.Get()
 		if err != nil {
 			panic(err)
@@ -1277,7 +1277,7 @@ func newTestProxy(cfg *Config, cm *certmanager.CertManager) *Proxy {
 	if err != nil {
 		panic(err)
 	}
-	store := storage.New(filepath.Join(cfg.CacheDir, "test"), mk)
+	store := storage.New(filepath.Join(*cfg.CacheDir, "test"), mk)
 	tm, err := tokenmanager.New(store, tpmSim, nil)
 	if err != nil {
 		panic(err)
@@ -1649,4 +1649,8 @@ func (c *pkiCert) TLSConfig() *tls.Config {
 	return &tls.Config{
 		Certificates: []tls.Certificate{c.cert},
 	}
+}
+
+func newPtr[T any](v T) *T {
+	return &v
 }

--- a/proxy/quic.go
+++ b/proxy/quic.go
@@ -71,7 +71,7 @@ func (p *Proxy) startQUIC(ctx context.Context) error {
 			return err
 		}
 	}
-	qt, err := netw.NewQUIC(p.cfg.TLSAddr, statelessResetKey)
+	qt, err := netw.NewQUIC(*p.cfg.TLSAddr, statelessResetKey)
 	if err != nil {
 		return err
 	}
@@ -184,9 +184,9 @@ func (p *Proxy) handleQUICConnection(qc *netw.QUICConn) {
 	qc.SetAnnotation(backendKey, be)
 	p.setCounters(qc, cs.ServerName)
 
-	if numOpen >= p.cfg.MaxOpen {
+	if numOpen >= *p.cfg.MaxOpen {
 		p.recordEvent("too many open connections")
-		be.logErrorF("ERR [%s] %s:%s: too many open connections: %d >= %d", sum, qc.RemoteAddr().Network(), qc.RemoteAddr(), numOpen, p.cfg.MaxOpen)
+		be.logErrorF("ERR [%s] %s:%s: too many open connections: %d >= %d", sum, qc.RemoteAddr().Network(), qc.RemoteAddr(), numOpen, *p.cfg.MaxOpen)
 		return
 	}
 

--- a/proxy/quic_test.go
+++ b/proxy/quic_test.go
@@ -71,10 +71,10 @@ func TestQUICConnections(t *testing.T) {
 	h2Value := "h2"
 
 	cfg := &Config{
-		HTTPAddr: "localhost:0",
-		TLSAddr:  "localhost:0",
-		CacheDir: t.TempDir(),
-		MaxOpen:  1000,
+		HTTPAddr: newPtr("localhost:0"),
+		TLSAddr:  newPtr("localhost:0"),
+		CacheDir: newPtr(t.TempDir()),
+		MaxOpen:  newPtr(1000),
 		Backends: []*Backend{
 			// TCP backend
 			{
@@ -215,10 +215,10 @@ func TestReverseProxyGetPost(t *testing.T) {
 
 	proxy := newTestProxy(
 		&Config{
-			HTTPAddr: "localhost:0",
-			TLSAddr:  "localhost:0",
-			CacheDir: t.TempDir(),
-			MaxOpen:  100,
+			HTTPAddr: newPtr("localhost:0"),
+			TLSAddr:  newPtr("localhost:0"),
+			CacheDir: newPtr(t.TempDir()),
+			MaxOpen:  newPtr(100),
 		},
 		extCA,
 	)
@@ -233,7 +233,7 @@ func TestReverseProxyGetPost(t *testing.T) {
 	h2Value := "h2"
 
 	cfg := &Config{
-		MaxOpen: 100,
+		MaxOpen: newPtr(100),
 		Backends: []*Backend{
 			// HTTP
 			{
@@ -435,10 +435,10 @@ func TestQUICMultiStream(t *testing.T) {
 	}()
 
 	cfg := &Config{
-		HTTPAddr: "localhost:0",
-		TLSAddr:  "localhost:0",
-		CacheDir: t.TempDir(),
-		MaxOpen:  1000,
+		HTTPAddr: newPtr("localhost:0"),
+		TLSAddr:  newPtr("localhost:0"),
+		CacheDir: newPtr(t.TempDir()),
+		MaxOpen:  newPtr(1000),
 		Backends: []*Backend{
 			{
 				ServerNames: []string{

--- a/proxy/sso_test.go
+++ b/proxy/sso_test.go
@@ -74,11 +74,11 @@ func TestSSOEnforceOIDC(t *testing.T) {
 
 			proxy := newTestProxy(
 				&Config{
-					HTTPAddr: "localhost:0",
-					TLSAddr:  "localhost:0",
-					CacheDir: t.TempDir(),
-					MaxOpen:  100,
-					HWBacked: tc.hwBacked,
+					HTTPAddr: newPtr("localhost:0"),
+					TLSAddr:  newPtr("localhost:0"),
+					CacheDir: newPtr(t.TempDir()),
+					MaxOpen:  newPtr(100),
+					HWBacked: newPtr(tc.hwBacked),
 					OIDCProviders: []*ConfigOIDC{
 						{
 							Name:          "test-idp",
@@ -249,11 +249,11 @@ func TestSSOEnforcePasskey(t *testing.T) {
 
 			proxy := newTestProxy(
 				&Config{
-					HTTPAddr: "localhost:0",
-					TLSAddr:  "localhost:0",
-					CacheDir: t.TempDir(),
-					MaxOpen:  100,
-					HWBacked: tc.hwBacked,
+					HTTPAddr: newPtr("localhost:0"),
+					TLSAddr:  newPtr("localhost:0"),
+					CacheDir: newPtr(t.TempDir()),
+					MaxOpen:  newPtr(100),
+					HWBacked: newPtr(tc.hwBacked),
 					OIDCProviders: []*ConfigOIDC{
 						{
 							Name:          "test-idp",

--- a/proxy/static_test.go
+++ b/proxy/static_test.go
@@ -74,10 +74,10 @@ func TestStaticFiles(t *testing.T) {
 
 	proxy := newTestProxy(
 		&Config{
-			HTTPAddr: "localhost:0",
-			TLSAddr:  "localhost:0",
-			CacheDir: t.TempDir(),
-			MaxOpen:  100,
+			HTTPAddr: newPtr("localhost:0"),
+			TLSAddr:  newPtr("localhost:0"),
+			CacheDir: newPtr(t.TempDir()),
+			MaxOpen:  newPtr(100),
 			Backends: []*Backend{
 				{
 					ServerNames: []string{

--- a/proxy/testdata/conf.d/part1.yaml
+++ b/proxy/testdata/conf.d/part1.yaml
@@ -1,0 +1,12 @@
+httpAddr: ":10080"
+tlsAddr: ":10443"
+
+backends:
+- serverNames: 
+  - example.com
+  - www.example.com
+  mode: http
+  addresses: 
+  - 192.168.0.10:80
+  - 192.168.0.11:80
+  - 192.168.0.12:80

--- a/proxy/testdata/conf.d/part2.yaml
+++ b/proxy/testdata/conf.d/part2.yaml
@@ -1,0 +1,7 @@
+backends:
+- serverNames:
+  - other.example.com
+  mode: https
+  addresses:
+  - 192.168.1.100:443
+  insecureSkipVerify: true

--- a/proxy/testdata/testconfig.yaml
+++ b/proxy/testdata/testconfig.yaml
@@ -1,0 +1,2 @@
+include:
+  - 'conf.d/*'


### PR DESCRIPTION
### Description

The config file can now be split across multiple files or directories with the 'include' directive, e.g.
```
include:
  - "conf/*.yaml"
 ```
### Type of change

* [x] New feature
* [ ] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)

### How is this change tested ?

* [x] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
