### PR TITLE
Add new tlsclient flag to use default go resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   include:
     - "conf/*.yaml"
   ```
+* tlsclient: New flag `--insecuredns` to use the default go resolver.
 
 ### :wrench: Misc
 


### PR DESCRIPTION
### Description

tlsclient: New flag `--insecuredns` to use the default go resolver.

### Type of change

* [x] New feature
* [ ] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)

### How is this change tested ?

* [ ] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
