### PR TITLE
Implement workaround for quic-go API change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # TLSPROXY Release Notes
 
+## next
+
+### :wrench: Misc
+
+* Switched to a [quic-go fork](https://github.com/c2FmZQ/quic-go-api/tree/v0.53.0) to workaround an API change that broke the integration with TLSPROXY. See https://github.com/c2FmZQ/tlsproxy/issues/211
+
 ## v0.16.0
 
 ### :star2: New features

--- a/go.mod
+++ b/go.mod
@@ -2,16 +2,12 @@ module github.com/c2FmZQ/tlsproxy
 
 go 1.24
 
-replace (
-	github.com/quic-go/quic-go => github.com/c2FmZQ/quic-go-api v0.53.0
-)
-
 require (
 	github.com/beevik/etree v1.5.1
 	github.com/c2FmZQ/ech v0.3.5
 	github.com/c2FmZQ/ech/publish v0.1.1
 	github.com/c2FmZQ/ech/quic v0.3.5
-	github.com/quic-go/quic-go v0.53.0
+	github.com/c2FmZQ/quic-go-api v0.53.0
 	github.com/c2FmZQ/storage v0.2.5
 	github.com/c2FmZQ/tpm v0.4.1
 	github.com/fxamacker/cbor/v2 v2.8.0
@@ -38,6 +34,8 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/onsi/ginkgo/v2 v2.23.4 // indirect
+	github.com/quic-go/qpack v0.5.1 // indirect
+	github.com/quic-go/quic-go v0.52.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.uber.org/mock v0.5.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/c2FmZQ/ech v0.3.5
 	github.com/c2FmZQ/ech/publish v0.1.1
 	github.com/c2FmZQ/ech/quic v0.3.5
+	github.com/c2FmZQ/quic-go-api v0.0.1
 	github.com/c2FmZQ/storage v0.2.5
 	github.com/c2FmZQ/tpm v0.4.1
 	github.com/fxamacker/cbor/v2 v2.8.0
@@ -17,7 +18,6 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/pires/go-proxyproto v0.8.1
-	github.com/quic-go/quic-go v0.52.0
 	github.com/russellhaering/goxmldsig v1.5.0
 	golang.org/x/crypto v0.38.0
 	golang.org/x/net v0.40.0
@@ -35,6 +35,7 @@ require (
 	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/onsi/ginkgo/v2 v2.23.4 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect
+	github.com/quic-go/quic-go v0.52.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.uber.org/mock v0.5.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/c2FmZQ/ech v0.3.5
 	github.com/c2FmZQ/ech/publish v0.1.1
 	github.com/c2FmZQ/ech/quic v0.3.5
-	github.com/c2FmZQ/quic-go-api v0.0.1
+	github.com/c2FmZQ/quic-go-api v0.53.0
 	github.com/c2FmZQ/storage v0.2.5
 	github.com/c2FmZQ/tpm v0.4.1
 	github.com/fxamacker/cbor/v2 v2.8.0

--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,16 @@ module github.com/c2FmZQ/tlsproxy
 
 go 1.24
 
+replace (
+	github.com/quic-go/quic-go => github.com/c2FmZQ/quic-go-api v0.53.0
+)
+
 require (
 	github.com/beevik/etree v1.5.1
 	github.com/c2FmZQ/ech v0.3.5
 	github.com/c2FmZQ/ech/publish v0.1.1
 	github.com/c2FmZQ/ech/quic v0.3.5
-	github.com/c2FmZQ/quic-go-api v0.53.0
+	github.com/quic-go/quic-go v0.53.0
 	github.com/c2FmZQ/storage v0.2.5
 	github.com/c2FmZQ/tpm v0.4.1
 	github.com/fxamacker/cbor/v2 v2.8.0
@@ -34,8 +38,6 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/onsi/ginkgo/v2 v2.23.4 // indirect
-	github.com/quic-go/qpack v0.5.1 // indirect
-	github.com/quic-go/quic-go v0.52.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.uber.org/mock v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/c2FmZQ/ech/publish v0.1.1 h1:NRrLalLZfQgEET3cqsiaR2Y5oB2V/do5ErAQ2boW
 github.com/c2FmZQ/ech/publish v0.1.1/go.mod h1:sUZW3FxGqL6optTBmmFgtwekpC86RkOC261wA/HUcK4=
 github.com/c2FmZQ/ech/quic v0.3.5 h1:a5hHKWO6Aa4+9F9PfrD10MRS7qsXEcfZJpFQIVZ5MLA=
 github.com/c2FmZQ/ech/quic v0.3.5/go.mod h1:I+FtUpJy6HW4tfCvFvdfIpeG3q5UteJx3Y+I0PhbPZg=
-github.com/c2FmZQ/quic-go-api v0.0.1 h1:alHHlObXONmwOJ/rsgLH+OMBN18cMTJn/6ttoTEoaTQ=
-github.com/c2FmZQ/quic-go-api v0.0.1/go.mod h1:nCdJaRnlXDrFeT2KuyW2BZnmctBG5yxzDa1VyiYdG0I=
+github.com/c2FmZQ/quic-go-api v0.53.0 h1:9iDasyVw2QDiPk1wHTeBFmVca0+Izx3zvrev9Tf+Vsc=
+github.com/c2FmZQ/quic-go-api v0.53.0/go.mod h1:nCdJaRnlXDrFeT2KuyW2BZnmctBG5yxzDa1VyiYdG0I=
 github.com/c2FmZQ/storage v0.2.5 h1:IUEym8AoEgS+wTisGUxFfcUEv5x/dBYJgm0OxSNwYCM=
 github.com/c2FmZQ/storage v0.2.5/go.mod h1:v4l4SdJGhg1dh+vxwPbgdhL1nG2ZZYxr9aaRwhNd6Ck=
 github.com/c2FmZQ/tpm v0.4.1 h1:CTEEsdcpEoymUeBj4RIkoImx3+DVSCWqTCDtc5IqFyE=

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/c2FmZQ/ech/publish v0.1.1 h1:NRrLalLZfQgEET3cqsiaR2Y5oB2V/do5ErAQ2boW
 github.com/c2FmZQ/ech/publish v0.1.1/go.mod h1:sUZW3FxGqL6optTBmmFgtwekpC86RkOC261wA/HUcK4=
 github.com/c2FmZQ/ech/quic v0.3.5 h1:a5hHKWO6Aa4+9F9PfrD10MRS7qsXEcfZJpFQIVZ5MLA=
 github.com/c2FmZQ/ech/quic v0.3.5/go.mod h1:I+FtUpJy6HW4tfCvFvdfIpeG3q5UteJx3Y+I0PhbPZg=
+github.com/c2FmZQ/quic-go-api v0.0.1 h1:alHHlObXONmwOJ/rsgLH+OMBN18cMTJn/6ttoTEoaTQ=
+github.com/c2FmZQ/quic-go-api v0.0.1/go.mod h1:nCdJaRnlXDrFeT2KuyW2BZnmctBG5yxzDa1VyiYdG0I=
 github.com/c2FmZQ/storage v0.2.5 h1:IUEym8AoEgS+wTisGUxFfcUEv5x/dBYJgm0OxSNwYCM=
 github.com/c2FmZQ/storage v0.2.5/go.mod h1:v4l4SdJGhg1dh+vxwPbgdhL1nG2ZZYxr9aaRwhNd6Ck=
 github.com/c2FmZQ/tpm v0.4.1 h1:CTEEsdcpEoymUeBj4RIkoImx3+DVSCWqTCDtc5IqFyE=

--- a/proxy/ech_test.go
+++ b/proxy/ech_test.go
@@ -34,7 +34,7 @@ import (
 	"testing"
 
 	"github.com/c2FmZQ/ech"
-	"github.com/c2FmZQ/quic-go-api"
+	"github.com/quic-go/quic-go"
 
 	"github.com/c2FmZQ/tlsproxy/certmanager"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/netw"

--- a/proxy/ech_test.go
+++ b/proxy/ech_test.go
@@ -34,7 +34,7 @@ import (
 	"testing"
 
 	"github.com/c2FmZQ/ech"
-	"github.com/quic-go/quic-go"
+	"github.com/c2FmZQ/quic-go-api"
 
 	"github.com/c2FmZQ/tlsproxy/certmanager"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/netw"

--- a/proxy/internal/netw/quic.go
+++ b/proxy/internal/netw/quic.go
@@ -37,7 +37,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/quic-go/quic-go"
+	"github.com/c2FmZQ/quic-go-api"
+	api "github.com/c2FmZQ/quic-go-api/api"
 	"golang.org/x/time/rate"
 
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/counter"
@@ -59,21 +60,22 @@ func NewQUIC(addr string, statelessResetKey quic.StatelessResetKey) (*QUICTransp
 	if err != nil {
 		return nil, err
 	}
+	tr := &quic.Transport{
+		Conn:              conn,
+		StatelessResetKey: &statelessResetKey,
+	}
 	return &QUICTransport{
-		qt: quic.Transport{
-			Conn:              conn,
-			StatelessResetKey: &statelessResetKey,
-		},
+		qt: &api.TransportWrapper{Base: tr},
 	}, nil
 }
 
 // QUICTransport is a wrapper around quic.Transport.
 type QUICTransport struct {
-	qt quic.Transport
+	qt api.Transport
 }
 
 func (t *QUICTransport) Addr() net.Addr {
-	return t.qt.Conn.LocalAddr()
+	return t.qt.(*api.TransportWrapper).Base.Conn.LocalAddr()
 }
 
 func (t *QUICTransport) Close() error {
@@ -108,7 +110,7 @@ func (t *QUICTransport) DialEarly(ctx context.Context, addr net.Addr, tc *tls.Co
 
 // QUICListener is a wrapper around quic.Listener.
 type QUICListener struct {
-	ln *quic.Listener
+	ln api.Listener
 }
 
 func (l *QUICListener) Accept(ctx context.Context) (*QUICConn, error) {
@@ -128,10 +130,9 @@ func (l *QUICListener) Close() error {
 }
 
 var _ net.Conn = (*QUICConn)(nil)
-var _ quic.Connection = (*QUICConn)(nil)
-var _ quic.EarlyConnection = (*QUICConn)(nil)
+var _ api.Conn = (*QUICConn)(nil)
 
-func newQUICConn(qc quic.Connection) *QUICConn {
+func newQUICConn(qc api.Conn) *QUICConn {
 	return &QUICConn{
 		qc:            qc,
 		bytesSent:     newCounter(),
@@ -141,7 +142,7 @@ func newQUICConn(qc quic.Connection) *QUICConn {
 
 // QUICConn is a wrapper around quic.Connection.
 type QUICConn struct {
-	qc quic.Connection
+	qc api.Conn
 
 	ingressLimiter *rate.Limiter
 	egressLimiter  *rate.Limiter
@@ -227,19 +228,11 @@ func (c *QUICConn) ByteRateReceived() float64 {
 }
 
 func (c *QUICConn) HandshakeComplete() <-chan struct{} {
-	if cc, ok := c.qc.(quic.EarlyConnection); ok {
-		return cc.HandshakeComplete()
-	}
-	ch := make(chan struct{})
-	close(ch)
-	return ch
+	return c.HandshakeComplete()
 }
 
-func (c *QUICConn) NextConnection(ctx context.Context) (quic.Connection, error) {
-	if cc, ok := c.qc.(quic.EarlyConnection); ok {
-		return cc.NextConnection(ctx)
-	}
-	return c.qc, nil
+func (c *QUICConn) NextConnection(ctx context.Context) (api.Conn, error) {
+	return c.NextConnection(ctx)
 }
 
 func (c *QUICConn) TLSConnectionState() tls.ConnectionState {
@@ -290,7 +283,7 @@ func (c *QUICConn) SetWriteDeadline(t time.Time) error {
 }
 
 func (c *QUICConn) WrapConn(s any) *Conn {
-	var stream quic.Stream
+	var stream api.Stream
 	switch v := s.(type) {
 	case *Conn:
 		return v
@@ -306,11 +299,11 @@ func (c *QUICConn) WrapConn(s any) *Conn {
 		maps.Copy(cc.annotations, c.annotations)
 		c.mu.Unlock()
 		return cc
-	case quic.Stream:
+	case api.Stream:
 		stream = v
-	case quic.SendStream:
+	case api.SendStream:
 		stream = &SendOnlyStream{v, c.Context()}
-	case quic.ReceiveStream:
+	case api.ReceiveStream:
 		stream = &ReceiveOnlyStream{v, c.Context()}
 	default:
 		log.Panicf("PANIC WrapConn called with %T", v)
@@ -343,11 +336,11 @@ func (c *QUICConn) ConnectionState() quic.ConnectionState {
 	return c.qc.ConnectionState()
 }
 
-func (c *QUICConn) AddPath(t *quic.Transport) (*quic.Path, error) {
+func (c *QUICConn) AddPath(t api.Transport) (api.Path, error) {
 	return c.qc.AddPath(t)
 }
 
-func (c *QUICConn) AcceptStream(ctx context.Context) (quic.Stream, error) {
+func (c *QUICConn) AcceptStream(ctx context.Context) (api.Stream, error) {
 	s, err := c.qc.AcceptStream(ctx)
 	if err != nil {
 		return nil, err
@@ -362,7 +355,7 @@ func (c *QUICConn) AcceptStream(ctx context.Context) (quic.Stream, error) {
 	return qs, nil
 }
 
-func (c *QUICConn) AcceptUniStream(ctx context.Context) (quic.ReceiveStream, error) {
+func (c *QUICConn) AcceptUniStream(ctx context.Context) (api.ReceiveStream, error) {
 	s, err := c.qc.AcceptUniStream(ctx)
 	if err != nil {
 		return nil, err
@@ -377,7 +370,7 @@ func (c *QUICConn) AcceptUniStream(ctx context.Context) (quic.ReceiveStream, err
 	return qs, nil
 }
 
-func (c *QUICConn) OpenStream() (quic.Stream, error) {
+func (c *QUICConn) OpenStream() (api.Stream, error) {
 	s, err := c.qc.OpenStream()
 	if err != nil {
 		return nil, err
@@ -392,7 +385,7 @@ func (c *QUICConn) OpenStream() (quic.Stream, error) {
 	return qs, nil
 }
 
-func (c *QUICConn) OpenStreamSync(ctx context.Context) (quic.Stream, error) {
+func (c *QUICConn) OpenStreamSync(ctx context.Context) (api.Stream, error) {
 	s, err := c.qc.OpenStreamSync(ctx)
 	if err != nil {
 		return nil, err
@@ -407,7 +400,7 @@ func (c *QUICConn) OpenStreamSync(ctx context.Context) (quic.Stream, error) {
 	return qs, nil
 }
 
-func (c *QUICConn) OpenUniStream() (quic.SendStream, error) {
+func (c *QUICConn) OpenUniStream() (api.SendStream, error) {
 	s, err := c.qc.OpenUniStream()
 	if err != nil {
 		return nil, err
@@ -422,7 +415,7 @@ func (c *QUICConn) OpenUniStream() (quic.SendStream, error) {
 	return qs, nil
 }
 
-func (c *QUICConn) OpenUniStreamSync(ctx context.Context) (quic.SendStream, error) {
+func (c *QUICConn) OpenUniStreamSync(ctx context.Context) (api.SendStream, error) {
 	s, err := c.qc.OpenUniStreamSync(ctx)
 	if err != nil {
 		return nil, err
@@ -453,12 +446,12 @@ func (c *QUICConn) ReceiveDatagram(ctx context.Context) ([]byte, error) {
 	return c.qc.ReceiveDatagram(ctx)
 }
 
-var _ quic.Stream = (*SendOnlyStream)(nil)
-var _ quic.Stream = (*ReceiveOnlyStream)(nil)
-var _ quic.Stream = (*QUICStream)(nil)
+var _ api.Stream = (*SendOnlyStream)(nil)
+var _ api.Stream = (*ReceiveOnlyStream)(nil)
+var _ api.Stream = (*QUICStream)(nil)
 
 type SendOnlyStream struct {
-	quic.SendStream
+	api.SendStream
 	ctx context.Context
 }
 
@@ -478,7 +471,7 @@ func (s *SendOnlyStream) SetDeadline(t time.Time) error {
 }
 
 type ReceiveOnlyStream struct {
-	quic.ReceiveStream
+	api.ReceiveStream
 	ctx context.Context
 }
 
@@ -510,7 +503,7 @@ var _ net.Conn = (*QUICStream)(nil)
 // QUICStream is a wrapper around quic.Stream that implements the net.Conn
 // interface.
 type QUICStream struct {
-	quic.Stream
+	api.Stream
 	qc *QUICConn
 
 	mu         sync.Mutex

--- a/proxy/internal/netw/quic.go
+++ b/proxy/internal/netw/quic.go
@@ -37,8 +37,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/c2FmZQ/quic-go-api"
-	quicapi "github.com/c2FmZQ/quic-go-api/api"
+	"github.com/quic-go/quic-go"
+	quicapi "github.com/quic-go/quic-go/api"
 	"golang.org/x/time/rate"
 
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/counter"

--- a/proxy/internal/netw/quic.go
+++ b/proxy/internal/netw/quic.go
@@ -37,8 +37,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/quic-go/quic-go"
-	quicapi "github.com/quic-go/quic-go/api"
+	"github.com/c2FmZQ/quic-go-api"
+	quicapi "github.com/c2FmZQ/quic-go-api/api"
 	"golang.org/x/time/rate"
 
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/counter"

--- a/proxy/quic.go
+++ b/proxy/quic.go
@@ -42,8 +42,9 @@ import (
 	"time"
 
 	"github.com/c2FmZQ/ech"
-	"github.com/quic-go/quic-go"
-	"github.com/quic-go/quic-go/http3"
+	"github.com/c2FmZQ/quic-go-api"
+	"github.com/c2FmZQ/quic-go-api/api"
+	"github.com/c2FmZQ/quic-go-api/http3"
 
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/netw"
 )
@@ -614,7 +615,7 @@ func (be *Backend) dialQUICBackend(ctx context.Context, proto string) (*netw.QUI
 func (be *Backend) http3Transport() http.RoundTripper {
 	return &http3.Transport{
 		DisableCompression: true,
-		Dial: func(ctx context.Context, _ string, _ *tls.Config, _ *quic.Config) (quic.EarlyConnection, error) {
+		Dial: func(ctx context.Context, _ string, _ *tls.Config, _ *quic.Config) (api.Conn, error) {
 			conn, err := be.dialQUICBackend(ctx, "h3")
 			if err != nil {
 				return nil, err
@@ -627,7 +628,7 @@ func (be *Backend) http3Transport() http.RoundTripper {
 func http3Server(handler http.Handler) *http3.Server {
 	return &http3.Server{
 		Handler: handler,
-		ConnContext: func(ctx context.Context, c quic.Connection) context.Context {
+		ConnContext: func(ctx context.Context, c api.Conn) context.Context {
 			if _, ok := c.(*netw.QUICConn); !ok {
 				panic(fmt.Sprintf("http3.Server.ConnContext called with: %#v", c))
 			}

--- a/proxy/quic.go
+++ b/proxy/quic.go
@@ -43,7 +43,7 @@ import (
 
 	"github.com/c2FmZQ/ech"
 	"github.com/c2FmZQ/quic-go-api"
-	"github.com/c2FmZQ/quic-go-api/api"
+	quicapi "github.com/c2FmZQ/quic-go-api/api"
 	"github.com/c2FmZQ/quic-go-api/http3"
 
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/netw"
@@ -615,7 +615,7 @@ func (be *Backend) dialQUICBackend(ctx context.Context, proto string) (*netw.QUI
 func (be *Backend) http3Transport() http.RoundTripper {
 	return &http3.Transport{
 		DisableCompression: true,
-		Dial: func(ctx context.Context, _ string, _ *tls.Config, _ *quic.Config) (api.Conn, error) {
+		Dial: func(ctx context.Context, _ string, _ *tls.Config, _ *quic.Config) (quicapi.Conn, error) {
 			conn, err := be.dialQUICBackend(ctx, "h3")
 			if err != nil {
 				return nil, err
@@ -628,7 +628,7 @@ func (be *Backend) http3Transport() http.RoundTripper {
 func http3Server(handler http.Handler) *http3.Server {
 	return &http3.Server{
 		Handler: handler,
-		ConnContext: func(ctx context.Context, c api.Conn) context.Context {
+		ConnContext: func(ctx context.Context, c quicapi.Conn) context.Context {
 			if _, ok := c.(*netw.QUICConn); !ok {
 				panic(fmt.Sprintf("http3.Server.ConnContext called with: %#v", c))
 			}

--- a/proxy/quic.go
+++ b/proxy/quic.go
@@ -42,9 +42,9 @@ import (
 	"time"
 
 	"github.com/c2FmZQ/ech"
-	"github.com/quic-go/quic-go"
-	quicapi "github.com/quic-go/quic-go/api"
-	"github.com/quic-go/quic-go/http3"
+	"github.com/c2FmZQ/quic-go-api"
+	quicapi "github.com/c2FmZQ/quic-go-api/api"
+	"github.com/c2FmZQ/quic-go-api/http3"
 
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/netw"
 )

--- a/proxy/quic.go
+++ b/proxy/quic.go
@@ -42,9 +42,9 @@ import (
 	"time"
 
 	"github.com/c2FmZQ/ech"
-	"github.com/c2FmZQ/quic-go-api"
-	quicapi "github.com/c2FmZQ/quic-go-api/api"
-	"github.com/c2FmZQ/quic-go-api/http3"
+	"github.com/quic-go/quic-go"
+	quicapi "github.com/quic-go/quic-go/api"
+	"github.com/quic-go/quic-go/http3"
 
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/netw"
 )

--- a/proxy/quic_test.go
+++ b/proxy/quic_test.go
@@ -43,9 +43,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/quic-go/quic-go"
-	quicapi "github.com/quic-go/quic-go/api"
-	"github.com/quic-go/quic-go/http3"
+	"github.com/c2FmZQ/quic-go-api"
+	quicapi "github.com/c2FmZQ/quic-go-api/api"
+	"github.com/c2FmZQ/quic-go-api/http3"
 
 	"github.com/c2FmZQ/tlsproxy/certmanager"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/netw"

--- a/proxy/quic_test.go
+++ b/proxy/quic_test.go
@@ -43,9 +43,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/c2FmZQ/quic-go-api"
-	quicapi "github.com/c2FmZQ/quic-go-api/api"
-	"github.com/c2FmZQ/quic-go-api/http3"
+	"github.com/quic-go/quic-go"
+	quicapi "github.com/quic-go/quic-go/api"
+	"github.com/quic-go/quic-go/http3"
 
 	"github.com/c2FmZQ/tlsproxy/certmanager"
 	"github.com/c2FmZQ/tlsproxy/proxy/internal/netw"


### PR DESCRIPTION
### Description

Temporary change to use a thin API layer around quic-go to restore lost functionality with the release of quic-go v0.53.0.

https://github.com/c2FmZQ/tlsproxy/issues/211

### Type of change

* [ ] New feature
* [ ] Feature improvement
* [x] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)

### How is this change tested ?

* [x] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
