### PR TITLE
Show groups only with groups scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # TLSPROXY Release Notes
 
+## next
+
+### :wrench: Misc
+
+* Only show groups when the groups scope is granted.
+* Require the openid scope to access /userinfo.
+
 ## v0.20.0
 
 ### :star2: New features

--- a/proxy/internal/oidc/server.go
+++ b/proxy/internal/oidc/server.go
@@ -595,8 +595,8 @@ func (s *ProviderServer) ServeUserInfo(w http.ResponseWriter, req *http.Request)
 		return
 	}
 	scopes, ok := userClaims["scope"].([]any)
-	if !ok || !slices.Contains(scopes, any("openid")) {
-		http.Error(w, "missing scope: openid", http.StatusUnauthorized)
+	if !ok {
+		http.Error(w, "missing scope", http.StatusUnauthorized)
 		return
 	}
 	var groups []string

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -107,6 +107,7 @@ const (
 	scopePKI      = "pki"
 	scopeSSH      = "ssh"
 	scopeSSO      = "sso"
+	scopeOpenID   = "openid"
 )
 
 var (
@@ -593,7 +594,7 @@ func (p *Proxy) Reconfigure(cfg *Config) error {
 						desc:    "OIDC Server Userinfo Endpoint",
 						path:    ls.PathPrefix + "/userinfo",
 						handler: logHandler(http.HandlerFunc(be.SSO.oidcServer.ServeUserInfo)),
-						scopes:  Strings{},
+						scopes:  Strings{scopeOpenID},
 					},
 					localHandler{
 						desc:      "OIDC Server JWKS Endpoint",


### PR DESCRIPTION
### Description

Only show groups when the *groups* scope is granted.
Require the *openid* scope to access `/userinfo`.

### Type of change

* [ ] New feature
* [x] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)

### How is this change tested ?

* [ ] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
