### PR TITLE
Fix lang matching bug

### DIFF
--- a/proxy/common.js
+++ b/proxy/common.js
@@ -55,8 +55,9 @@ window.tlsProxy = {
   };
 
   function setLanguage(langs) {
-    let opts = [...langs];
+    let opts = [];
     for (let lang of langs) {
+      opts.push(lang);
       const m = lang.split('-');
       if (m.length === 3) {
         opts.push(m[0]+'-'+m[2]);


### PR DESCRIPTION
### Description

Fix lang matching bug.

With ['en-US','es-US'], we should pick 'en'.

### Type of change

* [ ] New feature
* [ ] Feature improvement
* [x] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)

### How is this change tested ?

* [ ] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
