### PR TITLE
Clean up the ssh CA request parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # TLSPROXY Release Notes
 
+## next
+
+### :wrench: Misc
+
+* Clean up the ssh CA request parsing. When a specific ttl is desired, the request must now use `content-type: application/x-www-form-urlencoded`.
+
+# Please enter the commit message for your changes. Lines starting
+
 ## v0.22.2
 
 ### :wrench: Misc

--- a/proxy/internal/sshca/cert.html
+++ b/proxy/internal/sshca/cert.html
@@ -93,16 +93,13 @@ window.logout = logout;
 <script>
 let filename = '########';
 function getCert() {
-  let body = document.getElementById('key').value;
+  let body = 'key=' + encodeURIComponent(document.getElementById('key').value);
   const ttl = document.getElementById('ttl');
-  const ttlValue = ttl.options[ttl.selectedIndex].value;
-  if (ttlValue !== '') {
-    body += '\nttl=' + encodeURIComponent(ttlValue);
-  }
+  body += '&ttl=' + encodeURIComponent(ttl.options[ttl.selectedIndex].value);
   fetch(window.location, {
     method: 'POST',
     headers: {
-      'content-type': 'text/plain',
+      'content-type': 'application/x-www-form-urlencoded',
     },
     body: body,
   })


### PR DESCRIPTION
### Description

When a TTL is specified, the request must now use
application/x-www-form-urlencoded instead of text/plain.

When text/plain is used, the certificate will have the default lifetime.

### Type of change

* [ ] New feature
* [x] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [x] Cleanup / refactoring
* [ ] Other (please explain)

### How is this change tested ?

* [x] Unit tests
* [x] Manual tests (explain)
* [ ] Tests are not needed
