### PR TITLE
Set default read limit for POST requests

### DIFF
--- a/proxy/backend-http.go
+++ b/proxy/backend-http.go
@@ -477,6 +477,8 @@ func (be *Backend) handleLocalEndpointsAndAuthorize(w http.ResponseWriter, req *
 			return false
 		}
 		be.setAltSvc(w.Header(), req)
+		// Set a sensible limit for local handlers.
+		req.Body = http.MaxBytesReader(w, req.Body, 102400)
 		be.localHandlers[hi].handler.ServeHTTP(w, req)
 		return false
 	}

--- a/proxy/internal/pki/http.go
+++ b/proxy/internal/pki/http.go
@@ -162,8 +162,9 @@ func (m *PKIManager) ServeOCSP(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 		const maxSize = 4096
+		req.Body = http.MaxBytesReader(w, req.Body, maxSize)
 		var err error
-		if raw, err = io.ReadAll(&io.LimitedReader{R: req.Body, N: maxSize}); err != nil || len(raw) == maxSize {
+		if raw, err = io.ReadAll(req.Body); err != nil {
 			http.Error(w, "invalid request", http.StatusBadRequest)
 			return
 		}
@@ -365,7 +366,7 @@ func (m *PKIManager) handleRequestCert(w http.ResponseWriter, req *http.Request)
 		return
 	}
 	defer req.Body.Close()
-	body, err := io.ReadAll(&io.LimitedReader{R: req.Body, N: 102400})
+	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		m.opts.Logger.Errorf("ERR body: %v", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)

--- a/proxy/internal/sshca/sshca.go
+++ b/proxy/internal/sshca/sshca.go
@@ -311,7 +311,7 @@ func (ca *SSHCA) ServeCertificate(w http.ResponseWriter, req *http.Request) {
 	switch ct := req.Header.Get("content-type"); ct {
 	case "text/plain":
 		defer req.Body.Close()
-		body, err := io.ReadAll(&io.LimitedReader{R: req.Body, N: 102400})
+		body, err := io.ReadAll(req.Body)
 		if err != nil {
 			ca.opts.Logger.Errorf("ERR body: %v", err)
 			http.Error(w, "internal error", http.StatusInternalServerError)


### PR DESCRIPTION
### Description

The 100 KB read limit is applied to all POST request to local endpoints, e.g. login, logout, pki, sshca, etc.

### Type of change

* [ ] New feature
* [x] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)

### How is this change tested ?

* [x] Unit tests
* [ ] Manual tests (explain)
* [ ] Tests are not needed
