### PR TITLE
Add Ready() to jwks.Remote

### DIFF
--- a/jwks/remote.go
+++ b/jwks/remote.go
@@ -126,6 +126,7 @@ func (r *Remote) SetIssuers(issuers []Issuer) {
 			if ti.publicKeys == nil {
 				// avoid race condition with Ready()
 				close(ti.ready)
+				ti.publicKeys = make(map[string]crypto.PublicKey)
 			}
 			ti.cancel()
 			delete(r.trustedIssuers, k)

--- a/jwks/remote.go
+++ b/jwks/remote.go
@@ -123,6 +123,10 @@ func (r *Remote) SetIssuers(issuers []Issuer) {
 
 	for k, ti := range r.trustedIssuers {
 		if !inUse[k] {
+			if ti.publicKeys == nil {
+				// avoid race condition with Ready()
+				close(ti.ready)
+			}
 			ti.cancel()
 			delete(r.trustedIssuers, k)
 		}
@@ -142,6 +146,7 @@ func (r *Remote) Ready(ctx context.Context) {
 	for _, ready := range chans {
 		select {
 		case <-ctx.Done():
+			return
 		case <-ready:
 		}
 	}

--- a/jwks/remote_test.go
+++ b/jwks/remote_test.go
@@ -32,7 +32,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 )
 
 func TestRemote(t *testing.T) {
@@ -57,14 +56,7 @@ func TestRemote(t *testing.T) {
 		Issuer:  "https://example.com",
 		JWKSURI: ts.URL,
 	}})
-
-	// Wait for the key to be fetched
-	for i := 0; i < 10; i++ {
-		if _, err := r.GetKey(ks.Keys[0].ID); err == nil {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
+	r.Ready(t.Context())
 
 	pk, err := r.GetKey(ks.Keys[0].ID)
 	if err != nil {


### PR DESCRIPTION
### Description

Add Ready() to jwks.Remote. This function returns when all issuer keys have been fetched at least once.

### Type of change

* [ ] New feature
* [x] Feature improvement
* [ ] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)

### How is this change tested ?

* [x] Unit tests
* [ ] Manual tests (explain)
* [ ] Tests are not needed
